### PR TITLE
Reset refresh task after login failure

### DIFF
--- a/src/XRoadFolkRaw.Tests/TokenProviderTests.cs
+++ b/src/XRoadFolkRaw.Tests/TokenProviderTests.cs
@@ -94,4 +94,31 @@ public class TokenProviderTests
         Assert.All(tokens, t => Assert.Equal("TKN-ALL", t));
         client.Dispose();
     }
+
+    [Fact]
+    public async Task FailedLoginIsClearedForNextAttempt()
+    {
+        int calls = 0;
+        async Task<string> LoginAsync(CancellationToken ct)
+        {
+            calls++;
+            if (calls == 1)
+            {
+                await Task.Delay(1, ct);
+                throw new InvalidOperationException("nope");
+            }
+
+            return MakeLoginXml("OK", DateTimeOffset.UtcNow.AddMinutes(1));
+        }
+
+        FolkRawClient client = new("http://example/", null, TimeSpan.FromSeconds(10), null, false, true);
+        FolkTokenProviderRaw provider = new(client, LoginAsync);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => provider.GetTokenAsync());
+        string token = await provider.GetTokenAsync();
+
+        Assert.Equal("OK", token);
+        Assert.Equal(2, calls);
+        client.Dispose();
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `_refreshTask` is cleared when token refresh throws
- test that a failed login allows a subsequent successful retry

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f6917b58832b8e05755117efc0e0