### PR TITLE
Add namespace to core library classes

### DIFF
--- a/src/XRoadFolkRaw.Lib/FolkRawClient.cs
+++ b/src/XRoadFolkRaw.Lib/FolkRawClient.cs
@@ -4,6 +4,8 @@ using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 using Polly;
 
+namespace XRoadFolkRaw.Lib;
+
 public sealed class FolkRawClient : IDisposable
 {
     private readonly HttpClient _http;

--- a/src/XRoadFolkRaw.Lib/SoapSanitizer.cs
+++ b/src/XRoadFolkRaw.Lib/SoapSanitizer.cs
@@ -1,4 +1,7 @@
 using System.Text.RegularExpressions;
+
+namespace XRoadFolkRaw.Lib;
+
 public static class SoapSanitizer
 {
     private static readonly Regex UserRx = new("<username>(.*?)</username>", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);

--- a/src/XRoadFolkRaw.Lib/TokenHelper.cs
+++ b/src/XRoadFolkRaw.Lib/TokenHelper.cs
@@ -1,5 +1,7 @@
 using System.Xml.Linq;
 
+namespace XRoadFolkRaw.Lib;
+
 public sealed class FolkTokenProviderRaw
 {
     private readonly FolkRawClient _client;

--- a/src/XRoadFolkRaw.Tests/FolkRawClientRequestTests.cs
+++ b/src/XRoadFolkRaw.Tests/FolkRawClientRequestTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using XRoadFolkRaw.Lib;
 
 public class FolkRawClientRequestTests
 {

--- a/src/XRoadFolkRaw.Tests/LoginRequestTests.cs
+++ b/src/XRoadFolkRaw.Tests/LoginRequestTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using XRoadFolkRaw.Lib;
 
 public class LoginRequestTests
 {

--- a/src/XRoadFolkRaw.Tests/SoapSanitizerTests.cs
+++ b/src/XRoadFolkRaw.Tests/SoapSanitizerTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using XRoadFolkRaw.Lib;
 
 public class SoapSanitizerTests
 {

--- a/src/XRoadFolkRaw.Tests/TokenProviderTests.cs
+++ b/src/XRoadFolkRaw.Tests/TokenProviderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using XRoadFolkRaw.Lib;
 
 public class TokenProviderTests
 {


### PR DESCRIPTION
## Summary
- wrap `FolkRawClient`, `FolkTokenProviderRaw`, and `SoapSanitizer` in the `XRoadFolkRaw.Lib` namespace
- update tests to reference the library namespace

## Testing
- `dotnet test` *(fails: command not found)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f9a261d8832baa271166c8816833