### PR TITLE
Use compiled regex for name validation

### DIFF
--- a/src/XRoadFolkRaw.Lib/InputValidation.cs
+++ b/src/XRoadFolkRaw.Lib/InputValidation.cs
@@ -4,6 +4,8 @@ namespace XRoadFolkRaw.Lib
 {
     public static class InputValidation
     {
+        private static readonly Regex NameRegex = new(@"^[\p{L}][\p{L}\p{M}\s\-']{1,49}$", RegexOptions.Compiled);
+
         public static (bool Ok, List<string> Errors, string? SsnNorm, DateTimeOffset? Dob)
             ValidateCriteria(string? ssn, string? firstName, string? lastName, string? dobInput)
         {
@@ -61,7 +63,7 @@ namespace XRoadFolkRaw.Lib
 
             name = name.Trim();
             // Unicode letters + marks, spaces, hyphen, apostrophe; 2-50 chars
-            return Regex.IsMatch(name, @"^[\p{L}][\p{L}\p{M}\s\-']{1,49}$");
+            return NameRegex.IsMatch(name);
         }
 
         public static string NormalizeDigits(string? s)


### PR DESCRIPTION
## Summary
- cache the name validation regex with a compiled `Regex`
- use compiled regex for `IsValidName`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68a50f132560832b9b36591638eae8be