### PR TITLE
Use invariant culture for date parsing

### DIFF
--- a/src/XRoadFolkRaw.Lib/InputValidation.cs
+++ b/src/XRoadFolkRaw.Lib/InputValidation.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace XRoadFolkRaw.Lib
@@ -134,7 +135,8 @@ namespace XRoadFolkRaw.Lib
                 return false;
             }
 
-            if (!DateTimeOffset.TryParse(s, out DateTimeOffset dt))
+            if (!DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTimeOffset dt))
             {
                 return false;
             }

--- a/src/XRoadFolkRaw.Lib/TokenHelper.cs
+++ b/src/XRoadFolkRaw.Lib/TokenHelper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Xml.Linq;
 
 namespace XRoadFolkRaw.Lib;
@@ -89,7 +90,8 @@ public sealed class FolkTokenProviderRaw
 
         _token = tokenEl.Value.Trim();
 
-        if (expEl != null && DateTimeOffset.TryParse(expEl.Value.Trim(), out DateTimeOffset exp))
+        if (expEl != null && DateTimeOffset.TryParse(expEl.Value.Trim(), CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTimeOffset exp))
         {
             _expiresUtc = exp.ToUniversalTime();
         }

--- a/src/XRoadFolkRaw.Tests/AssemblyInfo.cs
+++ b/src/XRoadFolkRaw.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/src/XRoadFolkRaw.Tests/CultureParsingTests.cs
+++ b/src/XRoadFolkRaw.Tests/CultureParsingTests.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+using System.Reflection;
+using System.Threading.Tasks;
+using XRoadFolkRaw.Lib;
+using Xunit;
+
+public class CultureParsingTests
+{
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("fr-FR")]
+    public void TryParseDob_UsesInvariantCulture(string cultureName)
+    {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        CultureInfo originalUi = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+            CultureInfo.CurrentUICulture = new CultureInfo(cultureName);
+
+            bool ok = InputValidation.TryParseDob("01/02/1990", out DateTimeOffset? dob);
+            Assert.True(ok);
+            Assert.Equal(new DateTimeOffset(1990, 1, 2, 0, 0, 0, TimeSpan.Zero), dob);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+            CultureInfo.CurrentUICulture = originalUi;
+        }
+    }
+
+    [Theory]
+    [InlineData("en-US")]
+    [InlineData("fr-FR")]
+    public async Task RefreshAsync_ParsesExpirationInvariant(string cultureName)
+    {
+        string xml = "<root><token>abc</token><expires>01/02/2025 03:04:05 +00:00</expires></root>";
+        using FolkRawClient client = new("https://example.com");
+        FolkTokenProviderRaw provider = new(client, _ => Task.FromResult(xml));
+
+        CultureInfo original = CultureInfo.CurrentCulture;
+        CultureInfo originalUi = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+            CultureInfo.CurrentUICulture = new CultureInfo(cultureName);
+
+            await provider.GetTokenAsync();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+            CultureInfo.CurrentUICulture = originalUi;
+        }
+
+        FieldInfo? field = typeof(FolkTokenProviderRaw).GetField("_expiresUtc", BindingFlags.NonPublic | BindingFlags.Instance);
+        DateTimeOffset expires = (DateTimeOffset)field!.GetValue(provider)!;
+        Assert.Equal(new DateTimeOffset(2025, 1, 2, 3, 4, 5, TimeSpan.Zero), expires);
+    }
+}


### PR DESCRIPTION
## Summary
- Ensure DOB parsing uses invariant culture and explicit DateTimeStyles
- Parse token expiration with invariant culture
- Add tests verifying DOB and token expiration parsing across cultures

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a58dd5c2c8832ba898669f97a7cf55