### PR TITLE
Add tests for logging mask and SOAP sanitization

### DIFF
--- a/src/XRoadFolkRaw.Tests/LoggingHelperTests.cs
+++ b/src/XRoadFolkRaw.Tests/LoggingHelperTests.cs
@@ -1,0 +1,25 @@
+using XRoadFolkRaw.Lib;
+using Xunit;
+
+public class LoggingHelperTests
+{
+    [Theory]
+    [InlineData(null, 4, "")]
+    [InlineData("", 4, "")]
+    [InlineData("123456789", 0, "*********")]
+    [InlineData("abcdef", -2, "******")]
+    [InlineData("123456789", 4, "*****6789")]
+    [InlineData("abcd", 10, "abcd")]
+    public void MasksValuesCorrectly(string? value, int visible, string expected)
+    {
+        string result = LoggingHelper.Mask(value, visible);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void UsesDefaultVisibleOfFour()
+    {
+        string result = LoggingHelper.Mask("abcdefghij");
+        Assert.Equal("******ghij", result);
+    }
+}

--- a/src/XRoadFolkRaw.Tests/SafeSoapLoggerSanitizeTests.cs
+++ b/src/XRoadFolkRaw.Tests/SafeSoapLoggerSanitizeTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text.RegularExpressions;
+using XRoadFolkRaw.Lib.Logging;
+using Xunit;
+
+public class SafeSoapLoggerSanitizeTests
+{
+    [Fact]
+    public void SanitizesSensitiveElementsAndAttributes()
+    {
+        string xml = "<Envelope password=\"secret123\" apikey=\"apikey123\"><Body><Login><username>alice</username><password>p@ssw0rd</password><token>ABC123TOKEN</token></Login></Body></Envelope>";
+
+        string sanitized = SafeSoapLogger.Sanitize(xml);
+
+        Assert.DoesNotContain(">alice<", sanitized, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(">p@ssw0rd<", sanitized, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(">ABC123TOKEN<", sanitized, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("password=\"secret123\"", sanitized, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("apikey=\"apikey123\"", sanitized, StringComparison.OrdinalIgnoreCase);
+
+        Assert.Matches(new Regex("username>\\*+ce<", RegexOptions.IgnoreCase), sanitized);
+        Assert.Matches(new Regex("password>\\*+rd<", RegexOptions.IgnoreCase), sanitized);
+        Assert.Matches(new Regex("token>\\*+EN<", RegexOptions.IgnoreCase), sanitized);
+        Assert.Matches(new Regex("password=\\"\\*+23\\"", RegexOptions.IgnoreCase), sanitized);
+        Assert.Matches(new Regex("apikey=\\"\\*+23\\"", RegexOptions.IgnoreCase), sanitized);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests covering `LoggingHelper.Mask` with various values and visibility settings
- add tests ensuring `SafeSoapLogger.Sanitize` redacts sensitive elements and attributes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a59b934ed0832bb39a5a9e6c53dc07