### PR TITLE
Support multiple DOB formats

### DIFF
--- a/src/XRoadFolkRaw.Lib/InputValidation.cs
+++ b/src/XRoadFolkRaw.Lib/InputValidation.cs
@@ -135,8 +135,12 @@ namespace XRoadFolkRaw.Lib
                 return false;
             }
 
-            if (!DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture,
-                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTimeOffset dt))
+            if (!DateTimeOffset.TryParseExact(
+                    s,
+                    new[] { "yyyy-MM-dd", "dd-MM-yyyy" },
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out DateTimeOffset dt))
             {
                 return false;
             }

--- a/src/XRoadFolkRaw.Tests/ValidatorTests.cs
+++ b/src/XRoadFolkRaw.Tests/ValidatorTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Globalization;
 using Xunit;
 
 namespace XRoadFolkRaw.Tests
@@ -69,7 +70,12 @@ namespace XRoadFolkRaw.Tests
                     return false;
                 }
 
-                if (!DateTimeOffset.TryParse(s, out DateTimeOffset dt))
+                if (!DateTimeOffset.TryParseExact(
+                        s,
+                        new[] { "yyyy-MM-dd", "dd-MM-yyyy" },
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                        out DateTimeOffset dt))
                 {
                     return false;
                 }
@@ -141,6 +147,15 @@ namespace XRoadFolkRaw.Tests
         public void AcceptsNameAndDob()
         {
             (bool Ok, List<string> Errors, string? SsnNorm, DateTimeOffset? Dob) = ValidatorMirror.ValidateCriteria(null, "Páll", "Rasmussen", "1966-09-03");
+            Assert.True(Ok);
+            Assert.Null(SsnNorm);
+            Assert.NotNull(Dob);
+        }
+
+        [Fact]
+        public void AcceptsNameAndDobAlternateFormat()
+        {
+            (bool Ok, List<string> Errors, string? SsnNorm, DateTimeOffset? Dob) = ValidatorMirror.ValidateCriteria(null, "Páll", "Rasmussen", "03-09-1966");
             Assert.True(Ok);
             Assert.Null(SsnNorm);
             Assert.NotNull(Dob);

--- a/src/XRoadFolkRaw/ConsoleUi.cs
+++ b/src/XRoadFolkRaw/ConsoleUi.cs
@@ -24,7 +24,7 @@ internal sealed class ConsoleUi
         Console.WriteLine("==============================================");
         Console.WriteLine("INPUTS MODE: Strict");
         Console.WriteLine("Provide: SSN  OR  FirstName + LastName + DateOfBirth.");
-        Console.WriteLine("Example: FirstName=Anna, LastName=Olsen, DateOfBirth=1990-05-01");
+        Console.WriteLine("Example: FirstName=Anna, LastName=Olsen, DateOfBirth=1990-05-01 or 01-05-1990");
         Console.WriteLine("Type 'q' or press Ctrl+Q at any prompt to quit.");
         Console.WriteLine("==============================================");
 
@@ -38,7 +38,7 @@ internal sealed class ConsoleUi
             if (quit || IsQuit(fnInput)) { break; }
             string? lnInput = Prompt("LastName", out quit);
             if (quit || IsQuit(lnInput)) { break; }
-            string? dobInput = Prompt("DateOfBirth (YYYY-MM-DD)", out quit);
+            string? dobInput = Prompt("DateOfBirth (YYYY-MM-DD or DD-MM-YYYY)", out quit);
             if (quit || IsQuit(dobInput)) { break; }
 
             (bool Ok, List<string> Errors, string? SsnNorm, DateTimeOffset? Dob) = InputValidation.ValidateCriteria(ssnInput, fnInput, lnInput, dobInput);


### PR DESCRIPTION
## Summary
- parse DOB using exact formats `yyyy-MM-dd` and `dd-MM-yyyy`
- document both date formats in console prompts
- mirror new parsing logic in tests and cover alternate format

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a1c43d48832bbbab8b86144440f7