### PR TITLE
feat: add culture configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Provide a client certificate either as a single PFX file or as a PEM certificate
 - `XR_PEM_CERT_PATH` / `XR_PEM_KEY_PATH` – PEM certificate and key paths.
 - `DOTNET_ENVIRONMENT` – select which appsettings file to use (e.g. `Development`, `Production`).
 
+### Localization
+Specify the UI culture by setting `Localization:Culture` in `appsettings.json` (e.g. `en-US`, `fr-FR`). This culture is applied at startup for date and number formatting.
+
 ## Building and Running
 Restore dependencies and run the console application:
 ```bash

--- a/src/XRoadFolkRaw/Program.cs
+++ b/src/XRoadFolkRaw/Program.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using XRoad.Config;
@@ -19,6 +20,23 @@ using IDisposable _corr = LoggingHelper.BeginCorrelationScope(log);
 // Configuration
 ConfigurationLoader loader = new();
 (IConfigurationRoot config, XRoadSettings xr) = loader.Load(log);
+
+// Localization/globalization
+string? cultureName = config.GetValue<string>("Localization:Culture");
+if (!string.IsNullOrWhiteSpace(cultureName))
+{
+    try
+    {
+        CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        log.LogInformation("[culture] Using {Culture}", culture.Name);
+    }
+    catch (CultureNotFoundException)
+    {
+        log.LogWarning("[culture] Requested culture {Culture} not found, using defaults", cultureName);
+    }
+}
 
 // Startup banner
 Console.WriteLine("Press Ctrl+Q at any time to quit.\n");

--- a/src/XRoadFolkRaw/appsettings.json
+++ b/src/XRoadFolkRaw/appsettings.json
@@ -83,6 +83,9 @@
     "MaxPersons": 25,
     "ParallelDegree": 1
   },
+  "Localization": {
+    "Culture": "en-US"
+  },
   "GetPerson": {
     "Include": {
       "Address": true,


### PR DESCRIPTION
## Summary
- allow setting UI culture via `Localization:Culture` configuration
- apply culture at startup with graceful fallback

## Testing
- `dotnet test src/XRoadFolkRaw.Tests` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a36f4da8832b923ac6959ae18b4f