### PR TITLE
Localize input validation errors

### DIFF
--- a/src/XRoadFolkRaw.Lib/Resources/InputValidation.en-US.resx
+++ b/src/XRoadFolkRaw.Lib/Resources/InputValidation.en-US.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ProvideSsnOrNameDob" xml:space="preserve">
+    <value>Enter either SSN (9 digits) OR FirstName + LastName + DateOfBirth.</value>
+  </data>
+  <data name="InvalidSsn" xml:space="preserve">
+    <value>SSN must be 9 digits (allowing spaces/hyphens) and start with a valid date (ddMMyy).</value>
+  </data>
+  <data name="InvalidFirstName" xml:space="preserve">
+    <value>FirstName must be 2–50 letters (Unicode), allowing spaces, hyphens, apostrophes.</value>
+  </data>
+  <data name="InvalidLastName" xml:space="preserve">
+    <value>LastName must be 2–50 letters (Unicode), allowing spaces, hyphens, apostrophes.</value>
+  </data>
+  <data name="DobSsnMismatch" xml:space="preserve">
+    <value>DateOfBirth ({0}) does not match SSN date ({1}).</value>
+  </data>
+</root>

--- a/src/XRoadFolkRaw.Lib/Resources/InputValidation.resx
+++ b/src/XRoadFolkRaw.Lib/Resources/InputValidation.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ProvideSsnOrNameDob" xml:space="preserve">
+    <value>Enter either SSN (9 digits) OR FirstName + LastName + DateOfBirth.</value>
+  </data>
+  <data name="InvalidSsn" xml:space="preserve">
+    <value>SSN must be 9 digits (allowing spaces/hyphens) and start with a valid date (ddMMyy).</value>
+  </data>
+  <data name="InvalidFirstName" xml:space="preserve">
+    <value>FirstName must be 2–50 letters (Unicode), allowing spaces, hyphens, apostrophes.</value>
+  </data>
+  <data name="InvalidLastName" xml:space="preserve">
+    <value>LastName must be 2–50 letters (Unicode), allowing spaces, hyphens, apostrophes.</value>
+  </data>
+  <data name="DobSsnMismatch" xml:space="preserve">
+    <value>DateOfBirth ({0}) does not match SSN date ({1}).</value>
+  </data>
+</root>

--- a/src/XRoadFolkRaw.Lib/XRoadFolkRaw.Lib.csproj
+++ b/src/XRoadFolkRaw.Lib/XRoadFolkRaw.Lib.csproj
@@ -10,7 +10,14 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.8" />
     <PackageReference Include="Polly" Version="8.6.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Resources/InputValidation*.resx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/XRoadFolkRaw/ConsoleUi.cs
+++ b/src/XRoadFolkRaw/ConsoleUi.cs
@@ -12,13 +12,15 @@ internal sealed class ConsoleUi
     private readonly PeopleService _service;
     private readonly ILogger _log;
     private readonly IStringLocalizer<ConsoleUi> _loc;
+    private readonly IStringLocalizer<InputValidation> _valLoc;
 
-    public ConsoleUi(IConfiguration config, PeopleService service, ILogger log, IStringLocalizer<ConsoleUi> loc)
+    public ConsoleUi(IConfiguration config, PeopleService service, ILogger log, IStringLocalizer<ConsoleUi> loc, IStringLocalizer<InputValidation> valLoc)
     {
         _config = config;
         _service = service;
         _log = log;
         _loc = loc;
+        _valLoc = valLoc;
     }
 
     public async Task RunAsync()
@@ -44,7 +46,7 @@ internal sealed class ConsoleUi
             string? dobInput = Prompt(_loc["DateOfBirthPrompt"], out quit);
             if (quit || IsQuit(dobInput)) { break; }
 
-            (bool Ok, List<string> Errors, string? SsnNorm, DateTimeOffset? Dob) = InputValidation.ValidateCriteria(ssnInput, fnInput, lnInput, dobInput);
+            (bool Ok, List<string> Errors, string? SsnNorm, DateTimeOffset? Dob) = InputValidation.ValidateCriteria(ssnInput, fnInput, lnInput, dobInput, _valLoc);
             if (!Ok)
             {
                 Console.WriteLine(_loc["InputInvalid"]);

--- a/src/XRoadFolkRaw/Program.cs
+++ b/src/XRoadFolkRaw/Program.cs
@@ -68,11 +68,12 @@ CultureInfo.DefaultThreadCurrentCulture = culture;
 CultureInfo.DefaultThreadCurrentUICulture = culture;
 log.LogInformation("[culture] Using {Culture}", culture.Name);
 IStringLocalizer<ConsoleUi> localizer = provider.GetRequiredService<IStringLocalizer<ConsoleUi>>();
+IStringLocalizer<InputValidation> valLocalizer = provider.GetRequiredService<IStringLocalizer<InputValidation>>();
 LocalizedString check = localizer["BannerSeparator"];
 if (check.ResourceNotFound)
 {
     log.LogWarning("[culture] Resource 'BannerSeparator' not found for {Culture}", culture.Name);
 }
 
-ConsoleUi ui = new(config, service, log, localizer);
+ConsoleUi ui = new(config, service, log, localizer, valLocalizer);
 await ui.RunAsync();


### PR DESCRIPTION
## Summary
- catalogue input validation error keys and inject IStringLocalizer to fetch localized messages
- add InputValidation resource files and wire up localization in app
- hook up console UI and program to supply localized validator messages

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5aef956d0832bb59a2052e979b49a