### PR TITLE
Localize token missing error in PeopleService

### DIFF
--- a/src/XRoadFolkRaw.Lib/PeopleService.cs
+++ b/src/XRoadFolkRaw.Lib/PeopleService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using XRoad.Config;
 
@@ -10,17 +11,24 @@ public sealed class PeopleService
     private readonly IConfiguration _config;
     private readonly XRoadSettings _settings;
     private readonly ILogger _log;
+    private readonly IStringLocalizer<PeopleService> _localizer;
     private readonly FolkTokenProviderRaw _tokenProvider;
     private readonly string _loginXmlPath;
     private readonly string _peopleInfoXmlPath;
     private readonly string _personXmlPath;
 
-    public PeopleService(FolkRawClient client, IConfiguration config, XRoadSettings settings, ILogger log)
+    public PeopleService(
+        FolkRawClient client,
+        IConfiguration config,
+        XRoadSettings settings,
+        ILogger log,
+        IStringLocalizer<PeopleService> localizer)
     {
         _client = client;
         _config = config;
         _settings = settings;
         _log = log;
+        _localizer = localizer;
 
         _loginXmlPath = settings.Raw.LoginXmlPath;
         _peopleInfoXmlPath = _config.GetValue<string>("Operations:GetPeoplePublicInfo:XmlPath") ?? "GetPeoplePublicInfo.xml";
@@ -54,7 +62,7 @@ public sealed class PeopleService
         string token = await _tokenProvider.GetTokenAsync(ct);
         if (string.IsNullOrWhiteSpace(token))
         {
-            throw new InvalidOperationException("Token provider returned null/empty token.");
+            throw new InvalidOperationException(_localizer["TokenMissing"]);
         }
         _log.LogInformation("Token acquired (len={Len})", token.Length);
         return token;

--- a/src/XRoadFolkRaw.Lib/Resources/PeopleService.resx
+++ b/src/XRoadFolkRaw.Lib/Resources/PeopleService.resx
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TokenMissing" xml:space="preserve">
+    <value>Token provider returned null/empty token.</value>
+    <comment>Thrown when token provider returns a null or empty token.</comment>
+  </data>
+</root>

--- a/src/XRoadFolkRaw.Lib/XRoadFolkRaw.Lib.csproj
+++ b/src/XRoadFolkRaw.Lib/XRoadFolkRaw.Lib.csproj
@@ -21,6 +21,9 @@
     <EmbeddedResource Include="Resources/ConfigurationLoader*.resx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
+    <EmbeddedResource Include="Resources/PeopleService*.resx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/XRoadFolkRaw/Program.cs
+++ b/src/XRoadFolkRaw/Program.cs
@@ -30,6 +30,7 @@ preServices.AddLocalization(opts => opts.ResourcesPath = "Resources");
 using ServiceProvider preProvider = preServices.BuildServiceProvider();
 IStringLocalizer<ConfigurationLoader> cfgLocalizer = preProvider.GetRequiredService<IStringLocalizer<ConfigurationLoader>>();
 (IConfigurationRoot config, XRoadSettings xr) = loader.Load(log, cfgLocalizer);
+IStringLocalizer<PeopleService> serviceLocalizer = preProvider.GetRequiredService<IStringLocalizer<PeopleService>>();
 
 // Startup banner
 Console.WriteLine("Press Ctrl+Q at any time to quit.\n");
@@ -50,7 +51,7 @@ using FolkRawClient client = new(
     logger: log, verbose: verbose, maskTokens: maskTokens,
     retryAttempts: httpAttempts, retryBaseDelayMs: httpBaseDelay, retryJitterMs: httpJitter);
 
-PeopleService service = new(client, config, xr, log);
+PeopleService service = new(client, config, xr, log, serviceLocalizer);
 
 ServiceCollection services = new();
 services.AddSingleton<ILoggerFactory>(loggerFactory);


### PR DESCRIPTION
## Summary
- localize PeopleService token error via new resource file
- inject `IStringLocalizer<PeopleService>` and use it for token validation
- register PeopleService resources and wire up localization

## Testing
- `dotnet test` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b19c68c4832bbcea38f27c342558