### PR TITLE
Remove explicit embedded resource inclusion

### DIFF
--- a/src/XRoadFolkRaw.Lib/XRoadFolkRaw.Lib.csproj
+++ b/src/XRoadFolkRaw.Lib/XRoadFolkRaw.Lib.csproj
@@ -14,17 +14,6 @@
     <PackageReference Include="Polly" Version="8.6.2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Resources/InputValidation*.resx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Resources/ConfigurationLoader*.resx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Resources/PeopleService*.resx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">

--- a/src/XRoadFolkRaw/XRoadFolkRaw.csproj
+++ b/src/XRoadFolkRaw/XRoadFolkRaw.csproj
@@ -38,13 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources/*.resx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\XRoadFolkRaw.Lib\XRoadFolkRaw.Lib.csproj" />
+    <ProjectReference Include="..\\XRoadFolkRaw.Lib\\XRoadFolkRaw.Lib.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- drop manual EmbeddedResource includes from XRoadFolkRaw.Lib to avoid duplicate resource conflicts
- remove Resources/*.resx embedding from XRoadFolkRaw project file

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bd1c1a94832bab221835a1644794