### PR TITLE
refactor: make InputValidation non-static

### DIFF
--- a/src/XRoadFolkRaw.Lib/InputValidation.cs
+++ b/src/XRoadFolkRaw.Lib/InputValidation.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Localization;
 
 namespace XRoadFolkRaw.Lib
 {
-    public static class InputValidation
+    public class InputValidation
     {
         private static readonly Regex NameRegex = new(@"^[\p{L}][\p{L}\p{M}\s\-']{1,49}$", RegexOptions.Compiled);
 


### PR DESCRIPTION
## Summary
- allow InputValidation to be used as a generic type parameter by removing its static class declaration

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bf04bbd4832b8738f44dda88cea3