### PR TITLE
chore: remove Microsoft.AspNetCore.Localization reference

### DIFF
--- a/src/XRoadFolkRaw/XRoadFolkRaw.csproj
+++ b/src/XRoadFolkRaw/XRoadFolkRaw.csproj
@@ -14,7 +14,6 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Localization" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />


### PR DESCRIPTION
## Summary
- remove Microsoft.AspNetCore.Localization from XRoadFolkRaw project

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5caf22a38832ba3d37363b1bd6555