### PR TITLE
Use stable Microsoft.Extensions packages for .NET 8

### DIFF
--- a/src/XRoadFolkRaw.Lib/XRoadFolkRaw.Lib.csproj
+++ b/src/XRoadFolkRaw.Lib/XRoadFolkRaw.Lib.csproj
@@ -5,12 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.0" />
     <PackageReference Include="Polly" Version="8.6.2" />
   </ItemGroup>
 

--- a/src/XRoadFolkRaw/XRoadFolkRaw.csproj
+++ b/src/XRoadFolkRaw/XRoadFolkRaw.csproj
@@ -14,22 +14,22 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <!--PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" /-->
     <PackageReference Include="Polly" Version="8.6.2" />
     <!-- Generic Host (Host, IHostedService, CreateApplicationBuilder, etc.) -->
     <!--PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" /-->
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <!-- HttpClientFactory / AddHttpClient -->
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <!-- IConfiguration binding: services.Configure<T>(config.GetSection(...)) -->
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <!-- Console logger provider (AddSimpleConsole) -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="appsettings.json"><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>


### PR DESCRIPTION
## Summary
- downgrade Microsoft.Extensions.* package references from 9.0.8 to 8.0.0 for net8.0 compatibility

## Testing
- `dotnet restore` *(fails: command not found; network restrictions prevented installing the .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cc0cc39c832b8304e2c82d84e5db