### PR TITLE
Add missing ASP.NET Core builder namespace

### DIFF
--- a/src/XRoadFolkRaw/Program.cs
+++ b/src/XRoadFolkRaw/Program.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
## Summary
- include Microsoft.AspNetCore.Builder namespace in Program to resolve missing type error

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d0f54e90832bb614a7ab2f06c128