### PR TITLE
Register logger factory for localization

### DIFF
--- a/src/XRoadFolkRaw/Program.cs
+++ b/src/XRoadFolkRaw/Program.cs
@@ -27,6 +27,7 @@ using IDisposable _corr = LoggingHelper.BeginCorrelationScope(log);
 // Configuration
 ConfigurationLoader loader = new();
 ServiceCollection preServices = new();
+preServices.AddSingleton<ILoggerFactory>(loggerFactory);
 preServices.AddLocalization(opts => opts.ResourcesPath = "Resources");
 using ServiceProvider preProvider = preServices.BuildServiceProvider();
 IStringLocalizer<ConfigurationLoader> cfgLocalizer = preProvider.GetRequiredService<IStringLocalizer<ConfigurationLoader>>();


### PR DESCRIPTION
## Summary
- Register existing logger factory in temporary service provider so localization services resolve correctly

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*
- `dotnet run --project src/XRoadFolkRaw/XRoadFolkRaw.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d91abeec832b8e1f79a5a6c915c2