### PR TITLE
Ensure GetPerson XML template is copied to output

### DIFF
--- a/src/XRoadFolkRaw/XRoadFolkRaw.csproj
+++ b/src/XRoadFolkRaw/XRoadFolkRaw.csproj
@@ -35,6 +35,7 @@
     <None Include="appsettings.json"><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>
     <None Include="Login.xml"><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>
     <None Include="GetPeoplePublicInfo.xml"><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>
+    <None Include="GetPerson.xml"><CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory></None>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- include GetPerson.xml in project so it's copied to the output directory

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a628f5c4ac832bb99675a015ed019a