### PR TITLE
Mark ConfigurationLoader as partial

### DIFF
--- a/src/XRoadFolkRaw.Lib/ConfigurationLoader.cs
+++ b/src/XRoadFolkRaw.Lib/ConfigurationLoader.cs
@@ -5,7 +5,7 @@ using XRoad.Config;
 
 namespace XRoadFolkRaw.Lib;
 
-public sealed class ConfigurationLoader
+public sealed partial class ConfigurationLoader
 {
     public static class Messages
     {


### PR DESCRIPTION
## Summary
- mark ConfigurationLoader as partial so its generated logging methods compile

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed or 403)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a632318dfc832b8b1dfeb287b25ca5