### PR TITLE
Guard null parameters in configuration loader

### DIFF
--- a/src/XRoadFolkRaw.Lib/ConfigurationLoader.cs
+++ b/src/XRoadFolkRaw.Lib/ConfigurationLoader.cs
@@ -39,6 +39,8 @@ public sealed partial class ConfigurationLoader
 
     public (IConfigurationRoot Config, XRoadSettings Settings) Load(ILogger log, IStringLocalizer<ConfigurationLoader> loc)
     {
+        ArgumentNullException.ThrowIfNull(log);
+        ArgumentNullException.ThrowIfNull(loc);
         IConfigurationRoot config = new ConfigurationBuilder()
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)


### PR DESCRIPTION
## Summary
- Guard logger and localizer parameters against null in `ConfigurationLoader.Load`

## Testing
- ❌ `dotnet test` *(dotnet command not found)*
- ⚠️ `apt-get update` *(403 errors while attempting to install .NET SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68a636d10f9c832b850a1773a7df796a