### PR TITLE
Add null check for localizer

### DIFF
--- a/src/XRoadFolkRaw.Lib/InputValidation.cs
+++ b/src/XRoadFolkRaw.Lib/InputValidation.cs
@@ -20,6 +20,8 @@ namespace XRoadFolkRaw.Lib
         public static (bool Ok, List<string> Errors, string? SsnNorm, DateTimeOffset? Dob)
             ValidateCriteria(string? ssn, string? firstName, string? lastName, string? dobInput, IStringLocalizer<InputValidation> loc)
         {
+            ArgumentNullException.ThrowIfNull(loc);
+
             List<string> errs = [];
             string? ssnNorm = null;
 


### PR DESCRIPTION
## Summary
- guard ValidateCriteria against null localizer arguments

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a638339590832bbb6c546dc1c08ea7