### PR TITLE
Add null checks for PeopleService dependencies

### DIFF
--- a/src/XRoadFolkRaw.Lib/PeopleService.cs
+++ b/src/XRoadFolkRaw.Lib/PeopleService.cs
@@ -24,6 +24,12 @@ public sealed partial class PeopleService
         ILogger log,
         IStringLocalizer<PeopleService> localizer)
     {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(log);
+        ArgumentNullException.ThrowIfNull(localizer);
+
         _client = client;
         _config = config;
         _settings = settings;


### PR DESCRIPTION
## Summary
- guard PeopleService constructor dependencies with `ArgumentNullException.ThrowIfNull`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a63904a744832b9be9b1b5e01de2bb