### PR TITLE
Validate token before returning

### DIFF
--- a/src/XRoadFolkRaw.Lib/TokenHelper.cs
+++ b/src/XRoadFolkRaw.Lib/TokenHelper.cs
@@ -28,7 +28,7 @@ public sealed class FolkTokenProviderRaw
     {
         if (!NeedsRefresh())
         {
-            return _token!;
+            return _token ?? throw new InvalidOperationException("Token not initialized.");
         }
 
         Task<string> refresh;
@@ -37,7 +37,7 @@ public sealed class FolkTokenProviderRaw
         {
             if (!NeedsRefresh())
             {
-                return _token!;
+                return _token ?? throw new InvalidOperationException("Token not initialized.");
             }
 
             _refreshTask ??= RefreshAsync(ct);
@@ -100,7 +100,8 @@ public sealed class FolkTokenProviderRaw
             _expiresUtc = DateTimeOffset.UtcNow.AddMinutes(5);
         }
 
-        return _token!;
+        var token = _token ?? throw new InvalidOperationException("Token not parsed.");
+        return token;
     }
 
     private bool NeedsRefresh()


### PR DESCRIPTION
## Summary
- ensure a token is present before returning from GetTokenAsync
- validate parsed token in RefreshAsync before returning

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a63f3d3870832bb7da80efee8afe7a