### PR TITLE
Refactor certificate loading to explicit if blocks

### DIFF
--- a/src/XRoadFolkRaw.Lib/CertLoader.cs
+++ b/src/XRoadFolkRaw.Lib/CertLoader.cs
@@ -13,15 +13,33 @@ namespace XRoadFolkRaw.Lib
             string? envPemC = Environment.GetEnvironmentVariable("XR_PEM_CERT_PATH");
             string? envPemK = Environment.GetEnvironmentVariable("XR_PEM_KEY_PATH");
 
-            return !string.IsNullOrWhiteSpace(envPfx)
-                ? LoadFromPfx(envPfx, envPwd ?? cfg.PfxPassword)
-                : !string.IsNullOrWhiteSpace(envPemC) && !string.IsNullOrWhiteSpace(envPemK)
-                ? LoadFromPem(envPemC, envPemK)
-                : !string.IsNullOrWhiteSpace(cfg.PfxPath)
-                ? LoadFromPfx(cfg.PfxPath!, cfg.PfxPassword)
-                : !string.IsNullOrWhiteSpace(cfg.PemCertPath) && !string.IsNullOrWhiteSpace(cfg.PemKeyPath)
-                ? LoadFromPem(cfg.PemCertPath!, cfg.PemKeyPath!)
-                : throw new InvalidOperationException("No certificate configured.");
+            if (!string.IsNullOrWhiteSpace(envPfx))
+            {
+                var pfxPath = envPfx;
+                return LoadFromPfx(pfxPath, envPwd ?? cfg.PfxPassword);
+            }
+
+            if (!string.IsNullOrWhiteSpace(envPemC) && !string.IsNullOrWhiteSpace(envPemK))
+            {
+                var pemCertPath = envPemC;
+                var pemKeyPath = envPemK;
+                return LoadFromPem(pemCertPath, pemKeyPath);
+            }
+
+            if (!string.IsNullOrWhiteSpace(cfg.PfxPath))
+            {
+                var pfxPath = cfg.PfxPath;
+                return LoadFromPfx(pfxPath, cfg.PfxPassword);
+            }
+
+            if (!string.IsNullOrWhiteSpace(cfg.PemCertPath) && !string.IsNullOrWhiteSpace(cfg.PemKeyPath))
+            {
+                var pemCertPath = cfg.PemCertPath;
+                var pemKeyPath = cfg.PemKeyPath;
+                return LoadFromPem(pemCertPath, pemKeyPath);
+            }
+
+            throw new InvalidOperationException("No certificate configured.");
         }
         public static X509Certificate2 LoadFromPfx(string path, string? password = null)
         {


### PR DESCRIPTION
## Summary
- replace ternary cascade in CertLoader with explicit if/else blocks
- remove null-forgiving operators by assigning validated local variables

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a63ffc4b14832b83d6405dfc0c2622