### PR TITLE
Guard retry logging against null logger

### DIFF
--- a/src/XRoadFolkRaw.Lib/FolkRawClient.cs
+++ b/src/XRoadFolkRaw.Lib/FolkRawClient.cs
@@ -278,7 +278,11 @@ public sealed partial class FolkRawClient : IDisposable
                            .Or<TaskCanceledException>()
                            .WaitAndRetryAsync(_retryAttempts,
                                i => TimeSpan.FromMilliseconds((_retryBaseDelayMs * (1 << (i - 1))) + JitterRandom.Next(0, _retryJitterMs)),
-                               (ex, ts, attempt, ctx) => LogHttpRetryWarning(_log!, ex, attempt, ts.TotalMilliseconds));
+                               (ex, ts, attempt, ctx) =>
+                               {
+                                   if (_log != null)
+                                       LogHttpRetryWarning(_log, ex, attempt, ts.TotalMilliseconds);
+                               });
 
         string respText = await policy.ExecuteAsync(async () =>
         {


### PR DESCRIPTION
## Summary
- Wrap HTTP retry logging in a null-check before invoking LogHttpRetryWarning

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a641127a88832bbd2af62e640bf101