### PR TITLE
Check certificate file paths before existence check

### DIFF
--- a/src/XRoadFolkRaw.Lib/ConfigurationLoader.cs
+++ b/src/XRoadFolkRaw.Lib/ConfigurationLoader.cs
@@ -128,7 +128,7 @@ public sealed partial class ConfigurationLoader
             errs.Add(loc[Messages.ConfigureClientCertificate]);
         }
 
-        if (hasPfx && !File.Exists(pfx!))
+        if (pfx != null && !File.Exists(pfx))
         {
             errs.Add(loc[Messages.PfxFileNotFound, pfx]);
         }
@@ -141,12 +141,12 @@ public sealed partial class ConfigurationLoader
             }
             else
             {
-                if (!File.Exists(pemCert!))
+                if (pemCert != null && !File.Exists(pemCert))
                 {
                     errs.Add(loc[Messages.PemCertFileNotFound, pemCert]);
                 }
 
-                if (!File.Exists(pemKey!))
+                if (pemKey != null && !File.Exists(pemKey))
                 {
                     errs.Add(loc[Messages.PemKeyFileNotFound, pemKey]);
                 }


### PR DESCRIPTION
## Summary
- Safely verify X-Road client certificate files exist by checking path variables for null before calling `File.Exists`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6413e0e5c832b922653ca01237d9b