### PR TITLE
Handle ILogger scope and nullable exceptions in test logger

### DIFF
--- a/src/XRoadFolkRaw.Tests/SafeSoapLoggerTests.cs
+++ b/src/XRoadFolkRaw.Tests/SafeSoapLoggerTests.cs
@@ -8,9 +8,16 @@ public class SafeSoapLoggerTests
     private sealed class ListLogger : ILogger
     {
         public readonly System.Collections.Generic.List<string> Lines = [];
+        private sealed class NoOpDisposable : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+
         public IDisposable BeginScope<TState>(TState state)
         {
-            return default!;
+            return new NoOpDisposable();
         }
 
         public bool IsEnabled(LogLevel logLevel)
@@ -18,7 +25,7 @@ public class SafeSoapLoggerTests
             return true;
         }
 
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             Lines.Add(formatter(state, exception));
         }


### PR DESCRIPTION
## Summary
- Add no-op disposable used by ListLogger.BeginScope
- Update test logger's `Log` to accept nullable exceptions and formatter

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6414507d4832b8009e57ec411cf17