### PR TITLE
Assert field reflection result

### DIFF
--- a/src/XRoadFolkRaw.Tests/CultureParsingTests.cs
+++ b/src/XRoadFolkRaw.Tests/CultureParsingTests.cs
@@ -54,7 +54,8 @@ public class CultureParsingTests
         }
 
         FieldInfo? field = typeof(FolkTokenProviderRaw).GetField("_expiresUtc", BindingFlags.NonPublic | BindingFlags.Instance);
-        DateTimeOffset expires = (DateTimeOffset)field!.GetValue(provider)!;
+        Assert.NotNull(field);
+        var expires = (DateTimeOffset)field.GetValue(provider)!;
         Assert.Equal(new DateTimeOffset(2025, 1, 2, 3, 4, 5, TimeSpan.Zero), expires);
     }
 }


### PR DESCRIPTION
## Summary
- ensure `_expiresUtc` reflection field exists before using it
- eliminate null-forgiving operator on field and rely on assertion

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository unsigned/403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6414b32f8832b975b20f2d06ed7cb