### PR TITLE
Remove redundant using directive from tests

### DIFF
--- a/src/XRoadFolkRaw.Tests/PersonIdSelectionTests.cs
+++ b/src/XRoadFolkRaw.Tests/PersonIdSelectionTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- remove unnecessary System.Linq import from `PersonIdSelectionTests`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a650e2accc832b9449dbac746feb3c