### PR TITLE
Remove redundant usings from AppArtifactsTests

### DIFF
--- a/src/XRoadFolkRaw.Tests/AppArtifactsTests.cs
+++ b/src/XRoadFolkRaw.Tests/AppArtifactsTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using Xunit;
 
 public class AppArtifactsTests


### PR DESCRIPTION
## Summary
- remove unnecessary System usings from AppArtifactsTests

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a650ea9764832b93931c20372a7c44