### PR TITLE
chore: remove unused system usings in LoginRequestTests

### DIFF
--- a/src/XRoadFolkRaw.Tests/LoginRequestTests.cs
+++ b/src/XRoadFolkRaw.Tests/LoginRequestTests.cs
@@ -1,9 +1,6 @@
-using System;
-using System.IO;
 using System.Net.Sockets;
 using System.Net;
 using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 using XRoadFolkRaw.Lib;
 


### PR DESCRIPTION
## Summary
- remove unnecessary System using directives from LoginRequestTests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a650f4dc3c832b901de9d643af55d5