### PR TITLE
chore: remove unused usings in tests

### DIFF
--- a/src/XRoadFolkRaw.Tests/PositivePublicIdSelectionTests.cs
+++ b/src/XRoadFolkRaw.Tests/PositivePublicIdSelectionTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- remove unnecessary System and System.Linq usings in PositivePublicIdSelectionTests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a650f7c6b4832ba0391d5295fa2cc2