### PR TITLE
Remove redundant System usings from tests

### DIFF
--- a/src/XRoadFolkRaw.Tests/FolkRawClientRequestTests.cs
+++ b/src/XRoadFolkRaw.Tests/FolkRawClientRequestTests.cs
@@ -1,9 +1,6 @@
-using System;
-using System.IO;
 using System.Net.Sockets;
 using System.Net;
 using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 public class FolkRawClientRequestTests


### PR DESCRIPTION
## Summary
- remove unused System namespace directives from FolkRawClientRequestTests

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `curl -SL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_68a65100faac832bb86f55877b2fea22