### PR TITLE
Remove redundant Linq using directive

### DIFF
--- a/src/XRoadFolkRaw.Tests/NoFallbackWhenNoPublicIdTests.cs
+++ b/src/XRoadFolkRaw.Tests/NoFallbackWhenNoPublicIdTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- remove unnecessary `System.Linq` using from `NoFallbackWhenNoPublicIdTests`

## Testing
- `dotnet test src/XRoadFolkRaw.Tests/XRoadFolkRaw.Tests.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a651056978832b82cebd6cff602f5b