### PR TITLE
refactor: remove unused using directives in SoapAssert tests

### DIFF
--- a/src/XRoadFolkRaw.Tests/TestHelpers/SoapAssert.cs
+++ b/src/XRoadFolkRaw.Tests/TestHelpers/SoapAssert.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using System.Xml.Linq;
 using Xunit;
 
@@ -14,11 +12,11 @@ namespace XRoadFolkRaw.Tests.Helpers
         public static void HasElement(string xml, string localName, string? expectedValue = null)
         {
             XDocument doc = XDocument.Parse(xml, LoadOptions.PreserveWhitespace);
-            System.Collections.Generic.List<XElement> els = [.. doc.Descendants().Where(e => e.Name.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase))];
+            System.Collections.Generic.List<XElement> els = [.. System.Linq.Enumerable.Where(doc.Descendants(), e => e.Name.LocalName.Equals(localName, System.StringComparison.OrdinalIgnoreCase))];
             Assert.True(els.Count != 0, $"Expected element with local-name '{localName}' to exist.");
             if (expectedValue != null)
             {
-                Assert.Contains(els, e => (e.Value ?? string.Empty).Contains(expectedValue, StringComparison.Ordinal));
+                Assert.Contains(els, e => (e.Value ?? string.Empty).Contains(expectedValue, System.StringComparison.Ordinal));
             }
         }
 


### PR DESCRIPTION
## Summary
- drop redundant `System` and `System.Linq` usings from SoapAssert
- fully qualify types and LINQ methods so compilation no longer needs those imports

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a651094274832b8f40a9a46bfa2dea