### PR TITLE
Cleanup usings in test server helper

### DIFF
--- a/src/XRoadFolkRaw.Tests/TestHelpers/TestServer.cs
+++ b/src/XRoadFolkRaw.Tests/TestHelpers/TestServer.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace XRoadFolkRaw.Tests.Helpers
 {


### PR DESCRIPTION
## Summary
- remove redundant `using System` and `using System.Threading.Tasks` directives from `TestServer` helper

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6510cc138832b801baf39325b02f7