### PR TITLE
Remove redundant usings in TokenProviderTests

### DIFF
--- a/src/XRoadFolkRaw.Tests/TokenProviderTests.cs
+++ b/src/XRoadFolkRaw.Tests/TokenProviderTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 using XRoadFolkRaw.Lib;
 


### PR DESCRIPTION
## Summary
- drop unnecessary System-related using directives in TokenProviderTests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a65113b1a4832b83424ecfa755b16b