### PR TITLE
Remove unused usings in CertLoaderTests

### DIFF
--- a/src/XRoadFolkRaw.Tests/CertLoaderTests.cs
+++ b/src/XRoadFolkRaw.Tests/CertLoaderTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using XRoad.Config;


### PR DESCRIPTION
## Summary
- remove redundant `System` and `System.IO` usings from CertLoaderTests

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a6511893b4832b9801be81964706aa