### PR TITLE
Remove unused usings from Program

### DIFF
--- a/src/XRoadFolkRaw/Program.cs
+++ b/src/XRoadFolkRaw/Program.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
## Summary
- tidy Program.cs by removing redundant `System.Collections.Generic` and `System.Linq` usings

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6511d2128832b9704e8ca39f432a9