### PR TITLE
Discard unused StringBuilder return in login tests

### DIFF
--- a/src/XRoadFolkRaw.Tests/LoginRequestTests.cs
+++ b/src/XRoadFolkRaw.Tests/LoginRequestTests.cs
@@ -29,7 +29,7 @@ public class LoginRequestTests
                     break;
                 }
 
-                sb.Append(Encoding.UTF8.GetString(buffer, 0, read));
+                _ = sb.Append(Encoding.UTF8.GetString(buffer, 0, read));
                 string current = sb.ToString();
                 int headEnd = current.IndexOf("\r\n\r\n", StringComparison.Ordinal);
                 if (headEnd >= 0)
@@ -53,7 +53,7 @@ public class LoginRequestTests
                             break;
                         }
 
-                        sb.Append(Encoding.UTF8.GetString(buffer, 0, read));
+                        _ = sb.Append(Encoding.UTF8.GetString(buffer, 0, read));
                         current = sb.ToString();
                     }
                     break;


### PR DESCRIPTION
## Summary
- explicitly discard StringBuilder.Append return values in LoginRequestTests

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6580f0444832ba1f69bb285740c09