### PR TITLE
Explicitly discard StringBuilder.Append in tests

### DIFF
--- a/src/XRoadFolkRaw.Tests/FolkRawClientRequestTests.cs
+++ b/src/XRoadFolkRaw.Tests/FolkRawClientRequestTests.cs
@@ -24,7 +24,7 @@ public class FolkRawClientRequestTests
             {
                 read = await stream.ReadAsync(buffer, 0, buffer.Length);
                 if (read <= 0) break;
-                sb.Append(Encoding.UTF8.GetString(buffer, 0, read));
+                _ = sb.Append(Encoding.UTF8.GetString(buffer, 0, read));
                 var current = sb.ToString();
                 var headEnd = current.IndexOf("\r\n\r\n", StringComparison.Ordinal);
                 if (headEnd >= 0)
@@ -44,7 +44,7 @@ public class FolkRawClientRequestTests
                     {
                         read = await stream.ReadAsync(buffer, 0, buffer.Length);
                         if (read <= 0) break;
-                        sb.Append(Encoding.UTF8.GetString(buffer, 0, read));
+                        _ = sb.Append(Encoding.UTF8.GetString(buffer, 0, read));
                         current = sb.ToString();
                     }
                     break;


### PR DESCRIPTION
## Summary
- Discard unused `StringBuilder.Append` return values in `FolkRawClientRequestTests`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ac57a00832b991703e5dd7c1ed6