### PR TITLE
Remove unused expression comment

### DIFF
--- a/src/XRoadFolkRaw/ConsoleInput.cs
+++ b/src/XRoadFolkRaw/ConsoleInput.cs
@@ -36,7 +36,7 @@ namespace XRoadFolkRaw
                 {
                     continue;
                 }
-                _ = buf.Append(key.KeyChar); // IDE0058: Expression value is never used
+                _ = buf.Append(key.KeyChar);
                 Console.Write(key.KeyChar);
             }
         }


### PR DESCRIPTION
## Summary
- Remove redundant analyzer suppression comment in ConsoleInput

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a65b8a9110832b99363ebad2d12f39