### PR TITLE
Reuse DOB format array in Validator tests

### DIFF
--- a/src/XRoadFolkRaw.Tests/ValidatorTests.cs
+++ b/src/XRoadFolkRaw.Tests/ValidatorTests.cs
@@ -6,6 +6,7 @@ namespace XRoadFolkRaw.Tests
 {
     public static class ValidatorMirror
     {
+        private static readonly string[] DobFormats = { "yyyy-MM-dd", "dd-MM-yyyy" };
         public static (bool Ok, List<string> Errors, string? SsnNorm, DateTimeOffset? Dob) ValidateCriteria(
             string? ssn, string? firstName, string? lastName, string? dobInput)
         {
@@ -68,7 +69,7 @@ namespace XRoadFolkRaw.Tests
 
                 if (!DateTimeOffset.TryParseExact(
                         s,
-                        new[] { "yyyy-MM-dd", "dd-MM-yyyy" },
+                        DobFormats,
                         CultureInfo.InvariantCulture,
                         DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
                         out DateTimeOffset dt))


### PR DESCRIPTION
## Summary
- add reusable DobFormats array to ValidatorMirror
- use DobFormats in TryParseDob for birth date parsing

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a65eccfba4832b94c16bce8aa1f96e