### PR TITLE
Use string overload when splitting test headers

### DIFF
--- a/src/XRoadFolkRaw.Tests/FolkRawClientRequestTests.cs
+++ b/src/XRoadFolkRaw.Tests/FolkRawClientRequestTests.cs
@@ -32,7 +32,7 @@ public class FolkRawClientRequestTests
                     var headers = current.Substring(0, headEnd);
                     var bodyStart = headEnd + 4;
                     int contentLen = 0;
-                    foreach (var line in headers.Split(new[]{ "\r\n" }, StringSplitOptions.RemoveEmptyEntries))
+                    foreach (var line in headers.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
                     {
                         if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase))
                         {


### PR DESCRIPTION
## Summary
- Avoid array allocation when parsing HTTP headers in tests

## Testing
- ⚠️ `dotnet test` *(missing: dotnet CLI and package installation restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68a65f887c4c832b9444a7d62e793965