### PR TITLE
Use GeneratedRegex for sanitize test patterns

### DIFF
--- a/src/XRoadFolkRaw.Tests/SafeSoapLoggerSanitizeTests.cs
+++ b/src/XRoadFolkRaw.Tests/SafeSoapLoggerSanitizeTests.cs
@@ -2,7 +2,7 @@ using System.Text.RegularExpressions;
 using XRoadFolkRaw.Lib.Logging;
 using Xunit;
 
-public class SafeSoapLoggerSanitizeTests
+public partial class SafeSoapLoggerSanitizeTests
 {
     [Fact]
     public void SanitizesSensitiveElementsAndAttributes()
@@ -17,10 +17,25 @@ public class SafeSoapLoggerSanitizeTests
         Assert.DoesNotContain("password=\"secret123\"", sanitized, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("apikey=\"apikey123\"", sanitized, StringComparison.OrdinalIgnoreCase);
 
-        Assert.Matches(new Regex("username>\\*+ce<", RegexOptions.IgnoreCase), sanitized);
-        Assert.Matches(new Regex("password>\\*+rd<", RegexOptions.IgnoreCase), sanitized);
-        Assert.Matches(new Regex("token>\\*+EN<", RegexOptions.IgnoreCase), sanitized);
-        Assert.Matches(new Regex("password=\\"\\*+23\\"", RegexOptions.IgnoreCase), sanitized);
-        Assert.Matches(new Regex("apikey=\\"\\*+23\\"", RegexOptions.IgnoreCase), sanitized);
+        Assert.Matches(UsernameRegex(), sanitized);
+        Assert.Matches(PasswordRegex(), sanitized);
+        Assert.Matches(TokenRegex(), sanitized);
+        Assert.Matches(PasswordAttributeRegex(), sanitized);
+        Assert.Matches(ApiKeyAttributeRegex(), sanitized);
     }
+
+    [GeneratedRegex("username>\\*+ce<", RegexOptions.IgnoreCase)]
+    private static partial Regex UsernameRegex();
+
+    [GeneratedRegex("password>\\*+rd<", RegexOptions.IgnoreCase)]
+    private static partial Regex PasswordRegex();
+
+    [GeneratedRegex("token>\\*+EN<", RegexOptions.IgnoreCase)]
+    private static partial Regex TokenRegex();
+
+    [GeneratedRegex("password=\\\"\\*+23\\\"", RegexOptions.IgnoreCase)]
+    private static partial Regex PasswordAttributeRegex();
+
+    [GeneratedRegex("apikey=\\\"\\*+23\\\"", RegexOptions.IgnoreCase)]
+    private static partial Regex ApiKeyAttributeRegex();
 }


### PR DESCRIPTION
## Summary
- declare SafeSoapLoggerSanitizeTests partial and use GeneratedRegex methods for assertion patterns

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a662366de4832b86d441d322988d5a