### PR TITLE
Use GeneratedRegex for name validation

### DIFF
--- a/src/XRoadFolkRaw.Lib/InputValidation.cs
+++ b/src/XRoadFolkRaw.Lib/InputValidation.cs
@@ -4,10 +4,12 @@ using Microsoft.Extensions.Localization;
 
 namespace XRoadFolkRaw.Lib
 {
-    public class InputValidation
+    public partial class InputValidation
     {
-        private static readonly Regex NameRegex = new(@"^[\p{L}][\p{L}\p{M}\s\-']{1,49}$", RegexOptions.Compiled);
         private static readonly string[] DobFormats = { "yyyy-MM-dd", "dd-MM-yyyy" };
+
+        [GeneratedRegex("^[\\p{L}][\\p{L}\\p{M}\\s\\-']{1,49}$")]
+        private static partial Regex NameRegex();
 
         public static class Errors
         {
@@ -77,7 +79,7 @@ namespace XRoadFolkRaw.Lib
 
             name = name.Trim();
             // Unicode letters + marks, spaces, hyphen, apostrophe; 2-50 chars
-            return NameRegex.IsMatch(name);
+            return NameRegex().IsMatch(name);
         }
 
         public static string NormalizeDigits(string? s)


### PR DESCRIPTION
## Summary
- use source-generated regex for name validation
- refactor name check to call generated regex method

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a66418e450832b99abfa61383a3cf8