### PR TITLE
Replace Substring concatenation in SafeSoapLogger

### DIFF
--- a/src/XRoadFolkRaw.Lib/Logging/SafeSoapLogger.cs
+++ b/src/XRoadFolkRaw.Lib/Logging/SafeSoapLogger.cs
@@ -229,7 +229,8 @@ namespace XRoadFolkRaw.Lib.Logging
             }
             // Show only last 2 chars to help correlate, mask the rest
             int visible = Math.Min(2, s.Length);
-            return new string('*', Math.Max(0, s.Length - visible)) + s.Substring(s.Length - visible, visible);
+            int masked = Math.Max(0, s.Length - visible);
+            return string.Concat(new string('*', masked), s.AsSpan(s.Length - visible, visible));
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace string concatenation using Substring with string.Concat and AsSpan in SafeSoapLogger.Mask to avoid CA1845 warnings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a9cda904832bb17f2d71add557e9