### PR TITLE
Implement IDisposable for token provider

### DIFF
--- a/src/XRoadFolkRaw.Lib/TokenHelper.cs
+++ b/src/XRoadFolkRaw.Lib/TokenHelper.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 
 namespace XRoadFolkRaw.Lib;
 
-public sealed class FolkTokenProviderRaw
+public sealed class FolkTokenProviderRaw : IDisposable
 {
     private readonly FolkRawClient _client;
     private readonly TimeSpan _skew;
@@ -107,5 +107,10 @@ public sealed class FolkTokenProviderRaw
     private bool NeedsRefresh()
     {
         return string.IsNullOrWhiteSpace(_token) || DateTimeOffset.UtcNow.Add(_skew) >= _expiresUtc;
+    }
+
+    public void Dispose()
+    {
+        _gate.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- implement IDisposable in `FolkTokenProviderRaw`
- dispose of semaphore to satisfy CA1001 warning

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ad21c3a4832b9c815a230906fb73