### PR TITLE
Add optional certificate validation bypass in FolkRawClient

### DIFF
--- a/src/XRoadFolkRaw.Lib/FolkRawClient.cs
+++ b/src/XRoadFolkRaw.Lib/FolkRawClient.cs
@@ -21,16 +21,25 @@ public sealed partial class FolkRawClient : IDisposable
         new(["service", "client", "id", "protocolVersion", "userId"]);
     private readonly ConcurrentDictionary<string, XDocument> _templateCache = new(StringComparer.OrdinalIgnoreCase);
 
-    public FolkRawClient(string serviceUrl, X509Certificate2? clientCertificate = null, TimeSpan? timeout = null, ILogger? logger = null, bool verbose = false, bool maskTokens = true, int retryAttempts = 3, int retryBaseDelayMs = 200, int retryJitterMs = 250)
+    public FolkRawClient(
+        string serviceUrl,
+        X509Certificate2? clientCertificate = null,
+        TimeSpan? timeout = null,
+        ILogger? logger = null,
+        bool verbose = false,
+        bool maskTokens = true,
+        int retryAttempts = 3,
+        int retryBaseDelayMs = 200,
+        int retryJitterMs = 250,
+        bool bypassCertificateValidation = false)
     {
         ArgumentNullException.ThrowIfNull(serviceUrl);
 
-        //var handler = new HttpClientHandler();
-
-        HttpClientHandler handler = new()
+        HttpClientHandler handler = new();
+        if (bypassCertificateValidation)
         {
-            ServerCertificateCustomValidationCallback = (msg, cert, chain, errors) => true
-        };
+            handler.ServerCertificateCustomValidationCallback = (msg, cert, chain, errors) => true;
+        }
 
         if (clientCertificate != null)
         {


### PR DESCRIPTION
## Summary
- Add `bypassCertificateValidation` parameter to `FolkRawClient` to allow explicitly bypassing server certificate validation
- Use default certificate validation when flag is not set

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b1a90454832b8da4cf30e627ae07