### PR TITLE
Cache current time in SSN validation

### DIFF
--- a/src/XRoadFolkRaw.Lib/InputValidation.cs
+++ b/src/XRoadFolkRaw.Lib/InputValidation.cs
@@ -90,6 +90,7 @@ namespace XRoadFolkRaw.Lib
         public static bool LooksLikeValidSsn(string? s, out DateTimeOffset? embedded)
         {
             embedded = null;
+            DateTimeOffset now = DateTimeOffset.UtcNow;
             if (string.IsNullOrWhiteSpace(s))
             {
                 return false;
@@ -117,13 +118,13 @@ namespace XRoadFolkRaw.Lib
             }
 
             // Infer century 1900/2000 based on current year
-            int currYY = DateTimeOffset.UtcNow.Year % 100;
+            int currYY = now.Year % 100;
             int year = YY + (YY <= currYY ? 2000 : 1900);
 
             try
             {
                 DateTimeOffset dt = new(year, MM, DD, 0, 0, 0, TimeSpan.Zero);
-                if (dt.Date > DateTimeOffset.UtcNow.Date)
+                if (dt.Date > now.Date)
                 {
                     return false;
                 }


### PR DESCRIPTION
## Summary
- Cache `DateTimeOffset.UtcNow` at the start of SSN validation to ensure consistent comparisons

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b40add40832b986f0b257f88b41a