### PR TITLE
Supply defaults for UsingNameDob message

### DIFF
--- a/src/XRoadFolkRaw/ConsoleUi.cs
+++ b/src/XRoadFolkRaw/ConsoleUi.cs
@@ -64,7 +64,7 @@ internal sealed partial class ConsoleUi
             }
             else
             {
-                Console.WriteLine(_loc["UsingNameDob", fnInput, lnInput, Dob?.ToString("yyyy-MM-dd")]);
+                Console.WriteLine(_loc["UsingNameDob", fnInput ?? "", lnInput ?? "", Dob?.ToString("yyyy-MM-dd") ?? ""]);
             }
 
             string responseXml;


### PR DESCRIPTION
## Summary
- avoid passing null values in UsingNameDob console output

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b650734c832baf8e1c7009d0a459