### PR TITLE
Specify string type for certificate paths

### DIFF
--- a/src/XRoadFolkRaw.Lib/CertLoader.cs
+++ b/src/XRoadFolkRaw.Lib/CertLoader.cs
@@ -15,27 +15,27 @@ namespace XRoadFolkRaw.Lib
 
             if (!string.IsNullOrWhiteSpace(envPfx))
             {
-                var pfxPath = envPfx;
+                string pfxPath = envPfx;
                 return LoadFromPfx(pfxPath, envPwd ?? cfg.PfxPassword);
             }
 
             if (!string.IsNullOrWhiteSpace(envPemC) && !string.IsNullOrWhiteSpace(envPemK))
             {
-                var pemCertPath = envPemC;
-                var pemKeyPath = envPemK;
+                string pemCertPath = envPemC;
+                string pemKeyPath = envPemK;
                 return LoadFromPem(pemCertPath, pemKeyPath);
             }
 
             if (!string.IsNullOrWhiteSpace(cfg.PfxPath))
             {
-                var pfxPath = cfg.PfxPath;
+                string pfxPath = cfg.PfxPath;
                 return LoadFromPfx(pfxPath, cfg.PfxPassword);
             }
 
             if (!string.IsNullOrWhiteSpace(cfg.PemCertPath) && !string.IsNullOrWhiteSpace(cfg.PemKeyPath))
             {
-                var pemCertPath = cfg.PemCertPath;
-                var pemKeyPath = cfg.PemKeyPath;
+                string pemCertPath = cfg.PemCertPath;
+                string pemKeyPath = cfg.PemKeyPath;
                 return LoadFromPem(pemCertPath, pemKeyPath);
             }
 


### PR DESCRIPTION
## Summary
- use explicit `string` declarations for certificate path variables in `CertLoader`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bc3bab70832b9c0b3cceba50b717