### PR TITLE
refactor: replace var with explicit types in tests

### DIFF
--- a/src/XRoadFolkRaw.Tests/FolkRawClientRequestTests.cs
+++ b/src/XRoadFolkRaw.Tests/FolkRawClientRequestTests.cs
@@ -7,36 +7,36 @@ public class FolkRawClientRequestTests
 {
     private static async Task<(int Port, Task ServerTask, Func<string> GetCapturedRequest)> StartTestServerAsync(string responseBody)
     {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
+        TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();
         int port = ((IPEndPoint)listener.LocalEndpoint).Port;
 
         string captured = "";
         async Task Server()
         {
-            using var client = await listener.AcceptTcpClientAsync();
-            using var stream = client.GetStream();
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using NetworkStream stream = client.GetStream();
 
-            var buffer = new byte[8192];
+            byte[] buffer = new byte[8192];
             int read;
-            var sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder();
             do
             {
                 read = await stream.ReadAsync(buffer, 0, buffer.Length);
                 if (read <= 0) break;
                 _ = sb.Append(Encoding.UTF8.GetString(buffer, 0, read));
-                var current = sb.ToString();
-                var headEnd = current.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+                string current = sb.ToString();
+                int headEnd = current.IndexOf("\r\n\r\n", StringComparison.Ordinal);
                 if (headEnd >= 0)
                 {
-                    var headers = current.Substring(0, headEnd);
-                    var bodyStart = headEnd + 4;
+                    string headers = current.Substring(0, headEnd);
+                    int bodyStart = headEnd + 4;
                     int contentLen = 0;
-                    foreach (var line in headers.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
+                    foreach (string line in headers.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
                     {
                         if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase))
                         {
-                            var v = line.Substring("Content-Length:".Length).Trim();
+                            string v = line.Substring("Content-Length:".Length).Trim();
                             int.TryParse(v, out contentLen);
                         }
                     }
@@ -53,8 +53,8 @@ public class FolkRawClientRequestTests
 
             captured = sb.ToString();
 
-            var bodyBytes = Encoding.UTF8.GetBytes(responseBody);
-            var headersOut = "HTTP/1.1 200 OK\r\n" +
+            byte[] bodyBytes = Encoding.UTF8.GetBytes(responseBody);
+            string headersOut = "HTTP/1.1 200 OK\r\n" +
                              "Content-Type: text/xml; charset=utf-8\r\n" +
                              $"Content-Length: {bodyBytes.Length}\r\n" +
                              "Connection: close\r\n\r\n";
@@ -69,7 +69,7 @@ public class FolkRawClientRequestTests
 
     private static string ExtractBody(string rawHttp)
     {
-        var idx = rawHttp.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+        int idx = rawHttp.IndexOf("\r\n\r\n", StringComparison.Ordinal);
         return idx >= 0 ? rawHttp.Substring(idx + 4) : rawHttp;
     }
 
@@ -98,15 +98,15 @@ public class FolkRawClientRequestTests
     [Fact]
     public async Task GetPeoplePublicInfo_Inserts_Token_And_ServiceCode()
     {
-        var (port, serverTask, getReq) = await StartTestServerAsync(@"<Envelope><Body><GetPeoplePublicInfoResponse><ok>true</ok></GetPeoplePublicInfoResponse></Body></Envelope>");
-        var url = $"http://127.0.0.1:{port}/";
+        (int port, Task serverTask, Func<string> getReq) = await StartTestServerAsync(@"<Envelope><Body><GetPeoplePublicInfoResponse><ok>true</ok></GetPeoplePublicInfoResponse></Body></Envelope>");
+        string url = $"http://127.0.0.1:{port}/";
 
-        var tmp = Path.GetTempFileName();
+        string tmp = Path.GetTempFileName();
         File.WriteAllText(tmp, MinimalGetPeopleTemplate(), Encoding.UTF8);
 
-        var client = new FolkRawClient(url, null, TimeSpan.FromSeconds(5), logger:null, verbose:false, maskTokens:false);
+        FolkRawClient client = new FolkRawClient(url, null, TimeSpan.FromSeconds(5), logger:null, verbose:false, maskTokens:false);
 
-        var xml = await client.GetPeoplePublicInfoAsync(
+        string xml = await client.GetPeoplePublicInfoAsync(
             xmlPath: tmp,
             xId: "REQ-9",
             userId: "inspect",
@@ -125,11 +125,11 @@ public class FolkRawClientRequestTests
             ct: default);
 
         await serverTask;
-        var req = getReq();
+        string req = getReq();
 
         Assert.Contains("Content-Type: text/xml", req, StringComparison.OrdinalIgnoreCase);
 
-        var body = ExtractBody(req);
+        string body = ExtractBody(req);
 
         // prefix-agnostic body checks
         Assert.Contains("serviceCode>GetPeoplePublicInfo", body);


### PR DESCRIPTION
## Summary
- replace all usages of `var` with explicit types in `FolkRawClientRequestTests`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c440eef8832bb990de5b0571d50c