### PR TITLE
Use explicit tuple types in CertLoader tests

### DIFF
--- a/src/XRoadFolkRaw.Tests/CertLoaderTests.cs
+++ b/src/XRoadFolkRaw.Tests/CertLoaderTests.cs
@@ -29,8 +29,8 @@ public class CertLoaderTests
     [Fact]
     public void EnvironmentPfxOverridesConfig()
     {
-        var cfgCert = CreateTestCertificate("ConfigPfx");
-        var envCert = CreateTestCertificate("EnvPfx");
+        (string pfx, string cert, string key, string subject) cfgCert = CreateTestCertificate("ConfigPfx");
+        (string pfx, string cert, string key, string subject) envCert = CreateTestCertificate("EnvPfx");
 
         CertificateSettings cfg = new() { PfxPath = cfgCert.pfx };
 
@@ -50,8 +50,8 @@ public class CertLoaderTests
     [Fact]
     public void EnvironmentPemOverridesConfig()
     {
-        var cfgCert = CreateTestCertificate("ConfigPfx");
-        var envCert = CreateTestCertificate("EnvPem");
+        (string pfx, string cert, string key, string subject) cfgCert = CreateTestCertificate("ConfigPfx");
+        (string pfx, string cert, string key, string subject) envCert = CreateTestCertificate("EnvPem");
 
         CertificateSettings cfg = new() { PfxPath = cfgCert.pfx };
 


### PR DESCRIPTION
## Summary
- use explicit tuple declarations for test certificates in CertLoader tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c564a908832bb6143d5678990a9a