### PR TITLE
Use explicit DateTimeOffset in culture parsing test

### DIFF
--- a/src/XRoadFolkRaw.Tests/CultureParsingTests.cs
+++ b/src/XRoadFolkRaw.Tests/CultureParsingTests.cs
@@ -54,7 +54,7 @@ public class CultureParsingTests
 
         FieldInfo? field = typeof(FolkTokenProviderRaw).GetField("_expiresUtc", BindingFlags.NonPublic | BindingFlags.Instance);
         Assert.NotNull(field);
-        var expires = (DateTimeOffset)field.GetValue(provider)!;
+        DateTimeOffset expires = (DateTimeOffset)field.GetValue(provider)!;
         Assert.Equal(new DateTimeOffset(2025, 1, 2, 3, 4, 5, TimeSpan.Zero), expires);
     }
 }


### PR DESCRIPTION
## Summary
- use explicit `DateTimeOffset` variable in culture parsing test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c62c7c60832b8d3893b8075d3748