### PR TITLE
Align catch block braces in Console UI

### DIFF
--- a/src/XRoadFolkRaw/ConsoleUi.cs
+++ b/src/XRoadFolkRaw/ConsoleUi.cs
@@ -74,10 +74,10 @@ namespace XRoadFolkRaw
                     responseXml = await _service.GetPeoplePublicInfoAsync(SsnNorm, fnInput, lnInput, Dob);
                 }
                 catch (Exception ex)
-                    {
-                        LogFailedGetPeoplePublicInfo(_log, ex);
-                        continue;
-                    }
+                {
+                    LogFailedGetPeoplePublicInfo(_log, ex);
+                    continue;
+                }
     
                 if (string.IsNullOrWhiteSpace(responseXml))
                 {
@@ -88,10 +88,10 @@ namespace XRoadFolkRaw
                 XDocument listDoc;
                 try { listDoc = XDocument.Parse(responseXml); }
                 catch (Exception ex)
-                    {
-                        LogFailedParseGetPeoplePublicInfo(_log, ex);
-                        continue;
-                    }
+                {
+                    LogFailedParseGetPeoplePublicInfo(_log, ex);
+                    continue;
+                }
     
                 List<XElement> people = [.. listDoc.Descendants().Where(e => e.Name.LocalName == "PersonPublicInfo")];
                 if (people.Count == 0)
@@ -132,9 +132,9 @@ namespace XRoadFolkRaw
                         }
                     }
                     catch (Exception ex)
-                        {
-                            LogFailedGetPerson(_log, ex);
-                        }
+                    {
+                        LogFailedGetPerson(_log, ex);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Align braces with catch blocks in ConsoleUi to satisfy IDE0055 formatting guideline.

## Testing
- ⚠️ `dotnet format src/XRoadFolkRaw/ConsoleUi.cs` *(command not found)*
- ⚠️ `apt-get update` *(repository not signed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ce436cac832b9e3ba47a8f2a9a85