### PR TITLE
Refactor token expiry assignment in RefreshAsync

### DIFF
--- a/src/XRoadFolkRaw.Lib/TokenHelper.cs
+++ b/src/XRoadFolkRaw.Lib/TokenHelper.cs
@@ -91,15 +91,13 @@ namespace XRoadFolkRaw.Lib
     
             _token = tokenEl.Value.Trim();
     
-            if (expEl != null && DateTimeOffset.TryParse(expEl.Value.Trim(), CultureInfo.InvariantCulture,
-                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out DateTimeOffset exp))
-            {
-                _expiresUtc = exp.ToUniversalTime();
-            }
-            else
-            {
-                _expiresUtc = DateTimeOffset.UtcNow.AddMinutes(5);
-            }
+            _expiresUtc =
+                expEl != null &&
+                DateTimeOffset.TryParse(expEl.Value.Trim(), CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                    out DateTimeOffset exp)
+                    ? exp.ToUniversalTime()
+                    : DateTimeOffset.UtcNow.AddMinutes(5);
     
             string token = _token ?? throw new InvalidOperationException("Token not parsed.");
             return token;


### PR DESCRIPTION
## Summary
- simplify token expiry assignment using a conditional operator in `RefreshAsync`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cfcde994832bac7657a43a44d247