### PR TITLE
Allow single-letter inputs without quitting

### DIFF
--- a/src/XRoadFolkRaw.Tests/ConsoleInputTests.cs
+++ b/src/XRoadFolkRaw.Tests/ConsoleInputTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using XRoadFolkRaw;
+
+namespace XRoadFolkRaw.Tests
+{
+    public class ConsoleInputTests
+    {
+        [Fact]
+        public void ReadLineOrCtrlQ_AllowsSingleLetterQ()
+        {
+            var keys = new Queue<ConsoleKeyInfo>(new[]
+            {
+                new ConsoleKeyInfo('Q', ConsoleKey.Q, false, false, false),
+                new ConsoleKeyInfo('\r', ConsoleKey.Enter, false, false, false)
+            });
+
+            var original = ConsoleInput.ReadKey;
+            ConsoleInput.ReadKey = () => keys.Dequeue();
+            try
+            {
+                string? result = ConsoleInput.ReadLineOrCtrlQ(out bool quit);
+                Assert.False(quit);
+                Assert.Equal("Q", result);
+            }
+            finally
+            {
+                ConsoleInput.ReadKey = original;
+            }
+        }
+
+        [Fact]
+        public void ReadLineOrCtrlQ_QuitsOnCtrlQ()
+        {
+            var keys = new Queue<ConsoleKeyInfo>(new[]
+            {
+                new ConsoleKeyInfo('q', ConsoleKey.Q, false, false, true)
+            });
+
+            var original = ConsoleInput.ReadKey;
+            ConsoleInput.ReadKey = () => keys.Dequeue();
+            try
+            {
+                string? result = ConsoleInput.ReadLineOrCtrlQ(out bool quit);
+                Assert.True(quit);
+                Assert.Null(result);
+            }
+            finally
+            {
+                ConsoleInput.ReadKey = original;
+            }
+        }
+    }
+}

--- a/src/XRoadFolkRaw.Tests/XRoadFolkRaw.Tests.csproj
+++ b/src/XRoadFolkRaw.Tests/XRoadFolkRaw.Tests.csproj
@@ -15,5 +15,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\XRoadFolkRaw.Lib\XRoadFolkRaw.Lib.csproj" />
+    <ProjectReference Include="..\XRoadFolkRaw\XRoadFolkRaw.csproj" />
   </ItemGroup>
 </Project>

--- a/src/XRoadFolkRaw/AssemblyInfo.cs
+++ b/src/XRoadFolkRaw/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("XRoadFolkRaw.Tests")]

--- a/src/XRoadFolkRaw/ConsoleInput.cs
+++ b/src/XRoadFolkRaw/ConsoleInput.cs
@@ -5,13 +5,15 @@ namespace XRoadFolkRaw
 {
     internal static class ConsoleInput
     {
+        internal static Func<ConsoleKeyInfo> ReadKey { get; set; } = () => Console.ReadKey(intercept: true);
+
         public static string? ReadLineOrCtrlQ(out bool quit)
         {
             StringBuilder buf = new();
             quit = false;
             while (true)
             {
-                ConsoleKeyInfo key = Console.ReadKey(intercept: true);
+                ConsoleKeyInfo key = ReadKey();
                 if ((key.Modifiers & ConsoleModifiers.Control) != 0 && key.Key == ConsoleKey.Q)
                 {
                     Console.WriteLine();
@@ -47,7 +49,7 @@ namespace XRoadFolkRaw
             quit = false;
             while (true)
             {
-                ConsoleKeyInfo key = Console.ReadKey(intercept: true);
+                ConsoleKeyInfo key = ReadKey();
                 if ((key.Modifiers & ConsoleModifiers.Control) != 0 && key.Key == ConsoleKey.Q)
                 {
                     Console.WriteLine();

--- a/src/XRoadFolkRaw/ConsoleUi.cs
+++ b/src/XRoadFolkRaw/ConsoleUi.cs
@@ -30,13 +30,13 @@ namespace XRoadFolkRaw
                 Console.WriteLine();
                 Console.WriteLine(_loc["EnterSearchCriteria"]);
                 string? ssnInput = Prompt(_loc["SSN"], out bool quit);
-                if (quit || IsQuit(ssnInput)) { break; }
+                if (quit) { break; }
                 string? fnInput = Prompt(_loc["FirstName"], out quit);
-                if (quit || IsQuit(fnInput)) { break; }
+                if (quit) { break; }
                 string? lnInput = Prompt(_loc["LastName"], out quit);
-                if (quit || IsQuit(lnInput)) { break; }
+                if (quit) { break; }
                 string? dobInput = Prompt(_loc["DateOfBirthPrompt"], out quit);
-                if (quit || IsQuit(dobInput)) { break; }
+                if (quit) { break; }
 
                 (bool Ok, List<string> Errors, string? SsnNorm, DateTimeOffset? Dob) = InputValidation.ValidateCriteria(ssnInput, fnInput, lnInput, dobInput, _valLoc);
                 if (!Ok)
@@ -132,11 +132,6 @@ namespace XRoadFolkRaw
                     }
                 }
             }
-        }
-
-        private static bool IsQuit(string? s)
-        {
-            return string.Equals(s?.Trim(), "q", StringComparison.OrdinalIgnoreCase);
         }
 
         private static string? Prompt(string label, out bool quit)


### PR DESCRIPTION
## Summary
- Stop treating 'Q' as a quit command in Console UI prompts
- Expose ConsoleInput key reader for testing and support single-letter validation
- Add tests verifying 'Q' input and Ctrl+Q quit behavior

## Testing
- `apt-get update` *(fails: The repository is not signed)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e4fab020832ba2f1b9b93e105a36