### PR TITLE
Remove unused GetPeoplePublicInfoTable header

### DIFF
--- a/src/XRoadFolkRaw/ConsoleUi.cs
+++ b/src/XRoadFolkRaw/ConsoleUi.cs
@@ -281,7 +281,6 @@ namespace XRoadFolkRaw
                 Console.WriteLine(loc["NoRows"]);
                 return;
             }
-            PrintSeparator(loc["GetPeoplePublicInfoTable"]);
             const int wSsn = 12, wName = 28, wDob = 12, wGen = 8, wL1 = 26, wL2 = 26;
             Console.WriteLine($"{Trunc(loc["SSN"], wSsn)} {Trunc(loc["Name"], wName)} {Trunc(loc["DOB"], wDob)} {Trunc(loc["Gender"], wGen)} {Trunc(loc["Addr1"], wL1)} {Trunc(loc["Addr2"], wL2)}");
             Console.WriteLine(new string('-', 12 + 1 + 28 + 1 + 12 + 1 + 8 + 1 + 26 + 1 + 26));

--- a/src/XRoadFolkRaw/Resources/ConsoleUi.en-US.resx
+++ b/src/XRoadFolkRaw/Resources/ConsoleUi.en-US.resx
@@ -69,9 +69,6 @@
   <data name="NoRows" xml:space="preserve">
     <value>(no rows)</value>
   </data>
-  <data name="GetPeoplePublicInfoTable" xml:space="preserve">
-    <value>GetPeoplePublicInfo (table)</value>
-  </data>
   <data name="GetPersonAllPairs" xml:space="preserve">
     <value>GetPerson (all pairs)</value>
   </data>

--- a/src/XRoadFolkRaw/Resources/ConsoleUi.fo-FO.resx
+++ b/src/XRoadFolkRaw/Resources/ConsoleUi.fo-FO.resx
@@ -174,9 +174,6 @@
   <data name="NoRows" xml:space="preserve">
     <value>(no rows)</value>
   </data>
-  <data name="GetPeoplePublicInfoTable" xml:space="preserve">
-    <value>GetPeoplePublicInfo (table)</value>
-  </data>
   <data name="GetPersonAllPairs" xml:space="preserve">
     <value>GetPerson (all pairs)</value>
   </data>

--- a/src/XRoadFolkRaw/Resources/ConsoleUi.resx
+++ b/src/XRoadFolkRaw/Resources/ConsoleUi.resx
@@ -69,9 +69,6 @@
   <data name="NoRows" xml:space="preserve">
     <value>(no rows)</value>
   </data>
-  <data name="GetPeoplePublicInfoTable" xml:space="preserve">
-    <value>GetPeoplePublicInfo (table)</value>
-  </data>
   <data name="GetPersonAllPairs" xml:space="preserve">
     <value>GetPerson (all pairs)</value>
   </data>


### PR DESCRIPTION
## Summary
- drop the separator printed above the PeoplePublicInfo table
- remove GetPeoplePublicInfoTable entries from resource files

## Testing
- ❌ `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e824834c832bbdf1fb02eabe6511