### PR TITLE
Remove MaxPeopleToPrint output setting

### DIFF
--- a/src/XRoadFolkRaw/appsettings.json
+++ b/src/XRoadFolkRaw/appsettings.json
@@ -71,9 +71,6 @@
       "XmlPath": "GetPerson.xml"
     }
   },
-  "Output": {
-    "MaxPeopleToPrint": 25
-  },
   "Chaining": {
     "Enabled": true,
     "MaxPersons": 25,


### PR DESCRIPTION
## Summary
- remove unused Output:MaxPeopleToPrint configuration

## Testing
- `jq empty src/XRoadFolkRaw/appsettings.json` (after stripping comment)
- `dotnet test src/XRoadFolkRaw.Tests` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a701cccf5c832bb9b431e88dce55e0