### PR TITLE
Remove unused chaining config

### DIFF
--- a/src/XRoadFolkRaw/appsettings.json
+++ b/src/XRoadFolkRaw/appsettings.json
@@ -72,9 +72,7 @@
     }
   },
   "Chaining": {
-    "Enabled": true,
-    "MaxPersons": 25,
-    "ParallelDegree": 1
+    "MaxPersons": 25
   },
   "Localization": {
     "Culture": "fo-FO",


### PR DESCRIPTION
## Summary
- drop Enabled and ParallelDegree from Chaining config

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a702a78214832bb7b7b7c16cf391db