### PR TITLE
Remove console and log level settings from appsettings

### DIFF
--- a/src/XRoadFolkRaw/appsettings.json
+++ b/src/XRoadFolkRaw/appsettings.json
@@ -1,19 +1,7 @@
 {
   "Logging": {
     "Verbose": false,
-    "MaskTokens": true,
-    "Console": {
-      "Enabled": true,
-      "SingleLine": true,
-      "TimestampFormat": "HH:mm:ss ",
-      "IncludeScopes": false
-    },
-    "LogLevel": {
-      "Default": "Information",
-      "XRoadFolkRaw": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
+    "MaskTokens": true
   },
   "Retry": {
     "Http": {


### PR DESCRIPTION
## Summary
- simplify Logging configuration by removing Console and LogLevel sections while keeping Verbose and MaskTokens

## Testing
- `python - <<'PY' ...` (valid)
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7079acd6c832b9b0688fb449aae61