### PR TITLE
feat: add typed client example

### DIFF
--- a/src/XRoadFolkTyped/Program.cs
+++ b/src/XRoadFolkTyped/Program.cs
@@ -1,2 +1,57 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+using System.ServiceModel;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Configuration;
+using FOLKService.ServiceReference1;
+using XRoadFolkRaw.Lib;
+
+// Load configuration
+IConfigurationRoot config = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json", optional: false)
+    .Build();
+
+XRoadSettings xr = config.GetSection("XRoad").Get<XRoadSettings>() ?? new();
+
+// Load client certificate
+X509Certificate2 cert = CertLoader.LoadFromConfig(xr.Certificate);
+
+// Configure binding and endpoint
+BasicHttpsBinding binding = new(BasicHttpsSecurityMode.Transport)
+{
+    Security =
+    {
+        Transport = { ClientCredentialType = HttpClientCredentialType.Certificate }
+    }
+};
+
+EndpointAddress address = new(xr.BaseUrl);
+
+// Instantiate generated client
+using CrsPortTypeClient client = new(binding, address);
+client.ClientCredentials.ClientCertificate.Certificate = cert;
+
+// Prepare request for testSystem operation
+testSystemRequest request = new(
+    xr.Headers.ProtocolVersion,
+    Guid.NewGuid().ToString(),
+    new XRoadClientIdentifierType
+    {
+        xRoadInstance = xr.Client.XRoadInstance,
+        memberClass = xr.Client.MemberClass,
+        memberCode = xr.Client.MemberCode,
+        subsystemCode = xr.Client.SubsystemCode
+    },
+    new XRoadServiceIdentifierType
+    {
+        xRoadInstance = xr.Service.XRoadInstance,
+        memberClass = xr.Service.MemberClass,
+        memberCode = xr.Service.MemberCode,
+        subsystemCode = xr.Service.SubsystemCode,
+        serviceCode = xr.Service.ServiceCode,
+        serviceVersion = xr.Service.ServiceVersion
+    },
+    null!);
+
+// Call service and log response
+testSystemResponse response = await client.testSystemAsync(request);
+Console.WriteLine($"testSystemResponse: {response.testSystemResponse1 ?? "<null>"}");
+

--- a/src/XRoadFolkTyped/XRoadFolkTyped.csproj
+++ b/src/XRoadFolkTyped/XRoadFolkTyped.csproj
@@ -7,4 +7,19 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.ServiceModel.Http" Version="8.0.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\XRoadFolkRaw.Lib\\XRoadFolkRaw.Lib.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/XRoadFolkTyped/appsettings.json
+++ b/src/XRoadFolkTyped/appsettings.json
@@ -1,0 +1,32 @@
+{
+  "XRoad": {
+    "BaseUrl": "https://hn-heldinprod-c01.heilsunet.fo/FO/GOV/405388/us-folk-v2",
+    "Http": {
+      "TimeoutSeconds": 60
+    },
+    "Certificate": {
+      "PfxPath": "C:\\Users\\hn10901\\source\\repos\\TESTClient\\hnpv-cloudtar01.pfx",
+      "PfxPassword": "HXzV2NPJPsCVn8cQSJcs5MVeUD658LMP",
+      "PemCertPath": null,
+      "PemKeyPath": null
+    },
+    "Headers": {
+      "ProtocolVersion": "4.0"
+    },
+    "Client": {
+      "XRoadInstance": "FO",
+      "MemberClass": "GOV",
+      "MemberCode": "345334",
+      "SubsystemCode": "HN-Tardis"
+    },
+    "Service": {
+      "XRoadInstance": "FO",
+      "MemberClass": "GOV",
+      "MemberCode": "405388",
+      "SubsystemCode": "us-folk-v2",
+      "ServiceCode": "Login",
+      "ServiceVersion": "v1"
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- create typed Program to call testSystem via generated WCF client
- wire up WCF packages and configuration for typed project

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a72b22c4dc832b860d7e3db923b2cd