### PR TITLE
Expand DOB parsing formats and add tests

### DIFF
--- a/XRoadFolk.sln
+++ b/XRoadFolk.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XRoadFolkRaw.Lib", "src\XRo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XRoadFolkWeb", "src\XRoadFolkWeb\XRoadFolkWeb.csproj", "{059EF954-3109-4F12-8513-C985C9455E65}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XRoadFolkRaw.Tests", "src\XRoadFolkRaw.Tests\XRoadFolkRaw.Tests.csproj", "{6604EBBF-8333-4F79-A160-86C7A7C39AA5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{059EF954-3109-4F12-8513-C985C9455E65}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{059EF954-3109-4F12-8513-C985C9455E65}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{059EF954-3109-4F12-8513-C985C9455E65}.Release|Any CPU.Build.0 = Release|Any CPU
+                {6604EBBF-8333-4F79-A160-86C7A7C39AA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {6604EBBF-8333-4F79-A160-86C7A7C39AA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {6604EBBF-8333-4F79-A160-86C7A7C39AA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {6604EBBF-8333-4F79-A160-86C7A7C39AA5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/XRoadFolkRaw.Lib/InputValidation.cs
+++ b/src/XRoadFolkRaw.Lib/InputValidation.cs
@@ -6,7 +6,13 @@ namespace XRoadFolkRaw.Lib
 {
     public partial class InputValidation
     {
-        private static readonly string[] DobFormats = ["yyyy-MM-dd", "dd-MM-yyyy"];
+        private static readonly string[] DobFormats = [
+            "yyyy-MM-dd",
+            "dd-MM-yyyy",
+            "yyyy/MM/dd",
+            "dd.MM.yyyy",
+            "MM/dd/yyyy"
+        ];
 
         [GeneratedRegex("^[\\p{L}][\\p{L}\\p{M}\\s\\-']{1,49}$")]
         private static partial Regex NameRegex();
@@ -151,12 +157,23 @@ namespace XRoadFolkRaw.Lib
                 return false;
             }
 
-            if (!DateTimeOffset.TryParseExact(
+            bool ok = DateTimeOffset.TryParseExact(
+                s,
+                DobFormats,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out DateTimeOffset dt);
+
+            if (!ok)
+            {
+                ok = DateTimeOffset.TryParse(
                     s,
-                    DobFormats,
-                    CultureInfo.InvariantCulture,
+                    CultureInfo.CurrentCulture,
                     DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
-                    out DateTimeOffset dt))
+                    out dt);
+            }
+
+            if (!ok)
             {
                 return false;
             }

--- a/src/XRoadFolkRaw.Tests/InputValidationDobTests.cs
+++ b/src/XRoadFolkRaw.Tests/InputValidationDobTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Globalization;
+using XRoadFolkRaw.Lib;
+using Xunit;
+
+namespace XRoadFolkRaw.Tests;
+
+public class InputValidationDobTests
+{
+    [Theory]
+    [InlineData("1980/12/31")]
+    [InlineData("31.12.1980")]
+    [InlineData("12/31/1980")]
+    public void AcceptsAdditionalDobFormats(string input)
+    {
+        Assert.True(InputValidation.TryParseDob(input, out var dob));
+        Assert.Equal(new DateTimeOffset(1980, 12, 31, 0, 0, 0, TimeSpan.Zero), dob);
+    }
+
+    [Fact]
+    public void AcceptsCurrentCultureFormat()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+            string input = "31/12/1980";
+            Assert.True(InputValidation.TryParseDob(input, out var dob));
+            Assert.Equal(new DateTimeOffset(1980, 12, 31, 0, 0, 0, TimeSpan.Zero), dob);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+}

--- a/src/XRoadFolkRaw.Tests/XRoadFolkRaw.Tests.csproj
+++ b/src/XRoadFolkRaw.Tests/XRoadFolkRaw.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\XRoadFolkRaw.Lib\XRoadFolkRaw.Lib.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- expand accepted DOB formats and fall back to current culture parsing
- add unit tests for multiple DOB formats and localized parsing

## Testing
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8bacb2890832b9b212cfa1343afcf