### PR TITLE
Validate culture before setting cookie

### DIFF
--- a/src/XRoadFolkWeb/Program.cs
+++ b/src/XRoadFolkWeb/Program.cs
@@ -164,6 +164,13 @@ app.MapPost("/set-culture", async ([FromForm] string culture, [FromForm] string?
 {
     await af.ValidateRequestAsync(ctx);
 
+    // Ensure the requested culture is one of the supported UI cultures
+    bool supported = locOpts.SupportedUICultures.Any(c => string.Equals(c.Name, culture, StringComparison.OrdinalIgnoreCase));
+    if (!supported)
+    {
+        return Results.BadRequest();
+    }
+
     string cookieValue = CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture));
     ctx.Response.Cookies.Append(
         CookieRequestCultureProvider.DefaultCookieName,


### PR DESCRIPTION
## Summary
- Ensure `/set-culture` endpoint only accepts cultures from `SupportedUICultures`
- Return `400 Bad Request` when an unsupported culture is requested

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c434fe6c832b9faf532f1b38bc9d