### PR TITLE
Add Faroese and Danish resource translations

### DIFF
--- a/src/XRoadFolkRaw.Lib/Resources/ConfigurationLoader.da-DK.resx
+++ b/src/XRoadFolkRaw.Lib/Resources/ConfigurationLoader.da-DK.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="XRoadBaseUrlMissing" xml:space="preserve">
+    <value>XRoad.BaseUrl mangler.</value>
+  </data>
+  <data name="XRoadBaseUrlInvalidUri" xml:space="preserve">
+    <value>XRoad.BaseUrl er ikke en gyldig absolut URI: {0}</value>
+  </data>
+  <data name="XRoadHeadersProtocolVersionMissing" xml:space="preserve">
+    <value>XRoad.Headers.ProtocolVersion mangler.</value>
+  </data>
+  <data name="XRoadClientSectionMissing" xml:space="preserve">
+    <value>Sektionen XRoad.Client mangler.</value>
+  </data>
+  <data name="XRoadClientXRoadInstanceMissing" xml:space="preserve">
+    <value>XRoad.Client.XRoadInstance mangler.</value>
+  </data>
+  <data name="XRoadClientMemberClassMissing" xml:space="preserve">
+    <value>XRoad.Client.MemberClass mangler.</value>
+  </data>
+  <data name="XRoadClientMemberCodeMissing" xml:space="preserve">
+    <value>XRoad.Client.MemberCode mangler.</value>
+  </data>
+  <data name="XRoadClientSubsystemCodeMissing" xml:space="preserve">
+    <value>XRoad.Client.SubsystemCode mangler.</value>
+  </data>
+  <data name="XRoadServiceSectionMissing" xml:space="preserve">
+    <value>Sektionen XRoad.Service mangler.</value>
+  </data>
+  <data name="XRoadServiceXRoadInstanceMissing" xml:space="preserve">
+    <value>XRoad.Service.XRoadInstance mangler.</value>
+  </data>
+  <data name="XRoadServiceMemberClassMissing" xml:space="preserve">
+    <value>XRoad.Service.MemberClass mangler.</value>
+  </data>
+  <data name="XRoadServiceMemberCodeMissing" xml:space="preserve">
+    <value>XRoad.Service.MemberCode mangler.</value>
+  </data>
+  <data name="XRoadServiceSubsystemCodeMissing" xml:space="preserve">
+    <value>XRoad.Service.SubsystemCode mangler.</value>
+  </data>
+  <data name="XRoadAuthUserIdMissing" xml:space="preserve">
+    <value>XRoad.Auth.UserId mangler.</value>
+  </data>
+  <data name="XRoadTokenInsertModeInvalid" xml:space="preserve">
+    <value>XRoad.TokenInsert.Mode skal være 'request' eller 'header'.</value>
+  </data>
+  <data name="OperationsGetPeoplePublicInfoXmlPathNotFound" xml:space="preserve">
+    <value>Operations:GetPeoplePublicInfo:XmlPath fil ikke fundet: {0}</value>
+  </data>
+  <data name="OperationsGetPersonXmlPathNotFound" xml:space="preserve">
+    <value>Operations:GetPerson:XmlPath fil ikke fundet: {0}</value>
+  </data>
+  <data name="ConfigureClientCertificate" xml:space="preserve">
+    <value>Konfigurer et klientcertifikat (PFX eller PEM par).</value>
+  </data>
+  <data name="PfxFileNotFound" xml:space="preserve">
+    <value>PFX-fil ikke fundet: {0}</value>
+  </data>
+  <data name="PemModeRequiresBothPemCertPathAndPemKeyPath" xml:space="preserve">
+    <value>PEM-tilstand kræver både PemCertPath og PemKeyPath.</value>
+  </data>
+  <data name="PemCertFileNotFound" xml:space="preserve">
+    <value>PEM-certifikatfil ikke fundet: {0}</value>
+  </data>
+  <data name="PemKeyFileNotFound" xml:space="preserve">
+    <value>PEM-nøglefil ikke fundet: {0}</value>
+  </data>
+  <data name="ConfigSanityCheckFailedLog" xml:space="preserve">
+    <value>? Konfigurations-sanity-check mislykkedes:</value>
+  </data>
+  <data name="ConfigSanityCheckFailedException" xml:space="preserve">
+    <value>Konfigurations-sanity-check mislykkedes.</value>
+  </data>
+  <data name="XRoadClientSubsystemLog" xml:space="preserve">
+    <value>X-Road klient:  SUBSYSTEM:{Client}</value>
+  </data>
+  <data name="XRoadServiceSubsystemLog" xml:space="preserve">
+    <value>X-Road tjeneste: SUBSYSTEM:{Service}</value>
+  </data>
+</root>

--- a/src/XRoadFolkRaw.Lib/Resources/ConfigurationLoader.fo-FO.resx
+++ b/src/XRoadFolkRaw.Lib/Resources/ConfigurationLoader.fo-FO.resx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="XRoadBaseUrlMissing" xml:space="preserve">
+    <value>XRoad.BaseUrl manglar.</value>
+  </data>
+  <data name="XRoadBaseUrlInvalidUri" xml:space="preserve">
+    <value>XRoad.BaseUrl er ikki ein gyldugur absoluttur URI: {0}</value>
+  </data>
+  <data name="XRoadHeadersProtocolVersionMissing" xml:space="preserve">
+    <value>XRoad.Headers.ProtocolVersion manglar.</value>
+  </data>
+  <data name="XRoadClientSectionMissing" xml:space="preserve">
+    <value>XRoad.Client parturin manglar.</value>
+  </data>
+  <data name="XRoadClientXRoadInstanceMissing" xml:space="preserve">
+    <value>XRoad.Client.XRoadInstance manglar.</value>
+  </data>
+  <data name="XRoadClientMemberClassMissing" xml:space="preserve">
+    <value>XRoad.Client.MemberClass manglar.</value>
+  </data>
+  <data name="XRoadClientMemberCodeMissing" xml:space="preserve">
+    <value>XRoad.Client.MemberCode manglar.</value>
+  </data>
+  <data name="XRoadClientSubsystemCodeMissing" xml:space="preserve">
+    <value>XRoad.Client.SubsystemCode manglar.</value>
+  </data>
+  <data name="XRoadServiceSectionMissing" xml:space="preserve">
+    <value>XRoad.Service parturin manglar.</value>
+  </data>
+  <data name="XRoadServiceXRoadInstanceMissing" xml:space="preserve">
+    <value>XRoad.Service.XRoadInstance manglar.</value>
+  </data>
+  <data name="XRoadServiceMemberClassMissing" xml:space="preserve">
+    <value>XRoad.Service.MemberClass manglar.</value>
+  </data>
+  <data name="XRoadServiceMemberCodeMissing" xml:space="preserve">
+    <value>XRoad.Service.MemberCode manglar.</value>
+  </data>
+  <data name="XRoadServiceSubsystemCodeMissing" xml:space="preserve">
+    <value>XRoad.Service.SubsystemCode manglar.</value>
+  </data>
+  <data name="XRoadAuthUserIdMissing" xml:space="preserve">
+    <value>XRoad.Auth.UserId manglar.</value>
+  </data>
+  <data name="XRoadTokenInsertModeInvalid" xml:space="preserve">
+    <value>XRoad.TokenInsert.Mode skal vera 'request' ella 'header'.</value>
+  </data>
+  <data name="OperationsGetPeoplePublicInfoXmlPathNotFound" xml:space="preserve">
+    <value>Operations:GetPeoplePublicInfo:XmlPath skráarketan varð ikki funnin: {0}</value>
+  </data>
+  <data name="OperationsGetPersonXmlPathNotFound" xml:space="preserve">
+    <value>Operations:GetPerson:XmlPath skráarketan varð ikki funnin: {0}</value>
+  </data>
+  <data name="ConfigureClientCertificate" xml:space="preserve">
+    <value>Stilla ein kundasertifikat (PFX ella PEM par).</value>
+  </data>
+  <data name="PfxFileNotFound" xml:space="preserve">
+    <value>PFX-fíla ikki funnin: {0}</value>
+  </data>
+  <data name="PemModeRequiresBothPemCertPathAndPemKeyPath" xml:space="preserve">
+    <value>PEM-støðan krevur bæði PemCertPath og PemKeyPath.</value>
+  </data>
+  <data name="PemCertFileNotFound" xml:space="preserve">
+    <value>PEM-cert-fíla ikki funnin: {0}</value>
+  </data>
+  <data name="PemKeyFileNotFound" xml:space="preserve">
+    <value>PEM-lykil-fíla ikki funnin: {0}</value>
+  </data>
+  <data name="ConfigSanityCheckFailedLog" xml:space="preserve">
+    <value>? Stillinga sanity check miseydnaðist:</value>
+  </data>
+  <data name="ConfigSanityCheckFailedException" xml:space="preserve">
+    <value>Stillinga sanity check miseydnaðist.</value>
+  </data>
+  <data name="XRoadClientSubsystemLog" xml:space="preserve">
+    <value>X-Road klientur:  SUBSYSTEM:{Client}</value>
+  </data>
+  <data name="XRoadServiceSubsystemLog" xml:space="preserve">
+    <value>X-Road tænasta: SUBSYSTEM:{Service}</value>
+  </data>
+</root>

--- a/src/XRoadFolkRaw.Lib/Resources/InputValidation.da-DK.resx
+++ b/src/XRoadFolkRaw.Lib/Resources/InputValidation.da-DK.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ProvideSsnOrNameDob" xml:space="preserve">
+    <value>Indtast enten SSN (9 cifre) ELLER Fornavn + Efternavn + Fødselsdato.</value>
+  </data>
+  <data name="InvalidSsn" xml:space="preserve">
+    <value>SSN skal være 9 cifre (tillader mellemrum/bindestreger) og begynde med en gyldig dato (ddMMyy).</value>
+  </data>
+  <data name="InvalidFirstName" xml:space="preserve">
+    <value>Fornavn skal være 2–50 bogstaver (Unicode) og må indeholde mellemrum, bindestreger og apostrofer.</value>
+  </data>
+  <data name="InvalidLastName" xml:space="preserve">
+    <value>Efternavn skal være 2–50 bogstaver (Unicode) og må indeholde mellemrum, bindestreger og apostrofer.</value>
+  </data>
+  <data name="DobSsnMismatch" xml:space="preserve">
+    <value>Fødselsdato ({0}) stemmer ikke overens med dato i SSN ({1}).</value>
+  </data>
+</root>

--- a/src/XRoadFolkRaw.Lib/Resources/InputValidation.fo-FO.resx
+++ b/src/XRoadFolkRaw.Lib/Resources/InputValidation.fo-FO.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ProvideSsnOrNameDob" xml:space="preserve">
+    <value>Skriva annaðhvørt SSN (9 tøl) ella fyrinavn + eftirnavn + føðingardag.</value>
+  </data>
+  <data name="InvalidSsn" xml:space="preserve">
+    <value>SSN skal vera 9 tøl (loyvir blankum/bindistregum) og byrja við gildum dato (ddMMyy).</value>
+  </data>
+  <data name="InvalidFirstName" xml:space="preserve">
+    <value>Fyrinavn skal vera 2–50 bókstavir (Unicode), og loyvir millumrúmum, bindistregum og apostrofum.</value>
+  </data>
+  <data name="InvalidLastName" xml:space="preserve">
+    <value>Eftirnavn skal vera 2–50 bókstavir (Unicode), og loyvir millumrúmum, bindistregum og apostrofum.</value>
+  </data>
+  <data name="DobSsnMismatch" xml:space="preserve">
+    <value>Føðingardagur ({0}) samsvarar ikki við dato í SSN ({1}).</value>
+  </data>
+</root>

--- a/src/XRoadFolkRaw.Lib/Resources/PeopleService.da-DK.resx
+++ b/src/XRoadFolkRaw.Lib/Resources/PeopleService.da-DK.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TokenMissing" xml:space="preserve">
+    <value>Tokenudbyderen returnerede et tomt token.</value>
+  </data>
+  <data name="PeoplePublicInfoError" xml:space="preserve">
+    <value>Fejl ved hentning af offentlige personoplysninger.</value>
+  </data>
+  <data name="PersonInfoError" xml:space="preserve">
+    <value>Fejl ved hentning af person.</value>
+  </data>
+</root>

--- a/src/XRoadFolkRaw.Lib/Resources/PeopleService.fo-FO.resx
+++ b/src/XRoadFolkRaw.Lib/Resources/PeopleService.fo-FO.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TokenMissing" xml:space="preserve">
+    <value>Tokenveitarin gav einki ella tómt token.</value>
+  </data>
+  <data name="PeoplePublicInfoError" xml:space="preserve">
+    <value>Villa kom fram við at heinta almennar fólkaupplýsingar.</value>
+  </data>
+  <data name="PersonInfoError" xml:space="preserve">
+    <value>Villa kom fram við at heinta persónin.</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- add Faroese and Danish resource files for input validation, people service and configuration loader
- ensure services already use `IStringLocalizer` for localized messages

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository unsigned / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c707daa4832b92acfeefaf1a7268