### PR TITLE
Use conditional selected for culture dropdown

### DIFF
--- a/src/XRoadFolkWeb/Pages/Shared/_Layout.cshtml
+++ b/src/XRoadFolkWeb/Pages/Shared/_Layout.cshtml
@@ -88,7 +88,7 @@
                             {
                                 var loc = SR[$"Culture_{c!.Name}"];
                                 var label = loc.ResourceNotFound ? c!.NativeName : loc.Value;
-                                <option value="@c!.Name" selected="@(c!.Name == currentUi)">@($"{label} ({c!.Name})")</option>
+                                <option value="@c!.Name" @(c!.Name == currentUi ? "selected" : null)>@($"{label} ({c!.Name})")</option>
                             }
                         </select>
                     </form>


### PR DESCRIPTION
## Summary
- ensure culture dropdown only adds the selected attribute when matching the current culture

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ceb9f9a0832b884609bb9079b5c1