### PR TITLE
Use page-specific localizer for Index page

### DIFF
--- a/src/XRoadFolkRaw.Tests/IndexModelLocalizationTests.cs
+++ b/src/XRoadFolkRaw.Tests/IndexModelLocalizationTests.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using XRoadFolkWeb.Pages;
+using Xunit;
+
+namespace XRoadFolkRaw.Tests;
+
+public class IndexModelLocalizationTests
+{
+    [Theory]
+    [InlineData("en-US", " (Name)")]
+    [InlineData("da-DK", " (Name)")]
+    [InlineData("fo-FO", " (Name)")]
+    public void SelectedNameSuffixFormat_ComesFromPageResources(string culture, string expected)
+    {
+        var services = new ServiceCollection();
+        services.AddLocalization(opts => opts.ResourcesPath = "Resources");
+        using var provider = services.BuildServiceProvider();
+
+        var localizer = provider.GetRequiredService<IStringLocalizer<IndexModel>>();
+
+        var previous = CultureInfo.CurrentUICulture;
+        CultureInfo.CurrentUICulture = new CultureInfo(culture);
+        try
+        {
+            LocalizedString str = localizer["SelectedNameSuffixFormat", "Name"];    
+            Assert.False(str.ResourceNotFound);
+            Assert.Equal(expected, str.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previous;
+        }
+    }
+}

--- a/src/XRoadFolkRaw.Tests/XRoadFolkRaw.Tests.csproj
+++ b/src/XRoadFolkRaw.Tests/XRoadFolkRaw.Tests.csproj
@@ -11,5 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XRoadFolkRaw.Lib\XRoadFolkRaw.Lib.csproj" />
+    <ProjectReference Include="..\XRoadFolkWeb\XRoadFolkWeb.csproj" />
   </ItemGroup>
 </Project>

--- a/src/XRoadFolkWeb/Pages/Index.cshtml.cs
+++ b/src/XRoadFolkWeb/Pages/Index.cshtml.cs
@@ -7,11 +7,11 @@ using XRoadFolkRaw.Lib;
 
 namespace XRoadFolkWeb.Pages
 {
-    public class IndexModel(PeopleService service, IStringLocalizer<InputValidation> valLoc, IStringLocalizer<XRoadFolkWeb.SharedResource> sr) : PageModel
+    public class IndexModel(PeopleService service, IStringLocalizer<InputValidation> valLoc, IStringLocalizer<IndexModel> loc) : PageModel
     {
         private readonly PeopleService _service = service;
         private readonly IStringLocalizer<InputValidation> _valLoc = valLoc;
-        private readonly IStringLocalizer<XRoadFolkWeb.SharedResource> _sr = sr;
+        private readonly IStringLocalizer<IndexModel> _loc = loc;
 
         [BindProperty] public string? Ssn { get; set; }
         [BindProperty] public string? FirstName { get; set; }
@@ -37,7 +37,7 @@ namespace XRoadFolkWeb.Pages
                     string? last = PersonDetails
                         ?.FirstOrDefault(p => p.Key.EndsWith(".LastName", StringComparison.OrdinalIgnoreCase)).Value;
                     SelectedNameSuffix = (!string.IsNullOrWhiteSpace(first) || !string.IsNullOrWhiteSpace(last))
-                        ? _sr["SelectedNameSuffixFormat", string.Join(" ", new[] { first, last }.Where(s => !string.IsNullOrWhiteSpace(s)))]
+                        ? _loc["SelectedNameSuffixFormat", string.Join(" ", new[] { first, last }.Where(s => !string.IsNullOrWhiteSpace(s)))]
                         : string.Empty;
                 }
                 catch (Exception ex)


### PR DESCRIPTION
## Summary
- Inject `IStringLocalizer<IndexModel>` into `IndexModel` instead of the shared resource localizer
- Replace `_sr` with page-specific `_loc` when formatting the selected name suffix
- Add tests ensuring `SelectedNameSuffixFormat` comes from `Resources/Pages/IndexModel.*.resx`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ef5f0580832b90dbcc9b0562d480