### PR TITLE
Add localized culture names for language switcher

### DIFF
--- a/src/XRoadFolkWeb/Resources/SharedResource.da-DK.resx
+++ b/src/XRoadFolkWeb/Resources/SharedResource.da-DK.resx
@@ -10,4 +10,7 @@
   <data name="Theme"><value>Tema</value></data>
   <data name="ToggleTheme"><value>Skift tema</value></data>
   <data name="BuiltWith"><value>Bygget med ASP.NET Core + Bootstrap</value></data>
+  <data name="Culture_en-US"><value>Engelsk</value></data>
+  <data name="Culture_fo-FO"><value>Færøsk</value></data>
+  <data name="Culture_da-DK"><value>Dansk</value></data>
 </root>

--- a/src/XRoadFolkWeb/Resources/SharedResource.fo-FO.resx
+++ b/src/XRoadFolkWeb/Resources/SharedResource.fo-FO.resx
@@ -10,4 +10,7 @@
   <data name="Theme"><value>Tema</value></data>
   <data name="ToggleTheme"><value>Skift tema</value></data>
   <data name="BuiltWith"><value>Bygt við ASP.NET Core + Bootstrap</value></data>
+  <data name="Culture_en-US"><value>Enskt</value></data>
+  <data name="Culture_fo-FO"><value>Føroyskt</value></data>
+  <data name="Culture_da-DK"><value>Danskt</value></data>
 </root>

--- a/src/XRoadFolkWeb/Resources/SharedResource.resx
+++ b/src/XRoadFolkWeb/Resources/SharedResource.resx
@@ -10,4 +10,7 @@
   <data name="Theme"><value>Theme</value></data>
   <data name="ToggleTheme"><value>Toggle theme</value></data>
   <data name="BuiltWith"><value>Built with ASP.NET Core + Bootstrap</value></data>
+  <data name="Culture_en-US"><value>English</value></data>
+  <data name="Culture_fo-FO"><value>Faroese</value></data>
+  <data name="Culture_da-DK"><value>Danish</value></data>
 </root>


### PR DESCRIPTION
## Summary
- add culture name translations to SharedResource files for English, Faroese, and Danish

## Testing
- ⚠️ `dotnet test` *(dotnet not installed)*
- ⚠️ `apt-get update` *(repositories forbidden, unable to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f8e59218832b91a23f5fd9db8a5d